### PR TITLE
Backports from the Key Exchange customization PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,9 +30,10 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-features -- -D warnings
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --all-features

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##  The OPAQUE key exchange protocol
+##  The OPAQUE key exchange protocol ![Build Status](https://github.com/novifinancial/opaque-ke/workflows/Rust%20CI/badge.svg)
 
 [OPAQUE](https://eprint.iacr.org/2018/163.pdf) is an asymmetric password-authenticated key exchange protocol. It allows a client to authenticate to a server using a password, without ever having to expose the plaintext password to the server.
 

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -39,7 +39,7 @@ pub trait SizedBytes: Sized + PartialEq {
 }
 
 /// A Keypair trait with public-private verification
-pub trait KeyPair: Sized + Debug {
+pub trait KeyPair: Sized {
     /// The single key representation must have a specific byte size itself
     type Repr: SizedBytes + Clone;
 
@@ -68,10 +68,12 @@ pub trait KeyPair: Sized + Debug {
 
     /// Computes the diffie hellman function on a public key and private key
     fn diffie_hellman(pk: Self::Repr, sk: Self::Repr) -> Vec<u8>;
+}
 
+#[cfg(test)]
+trait KeyPairExt: KeyPair + Debug {
     /// Test-only strategy returning a proptest Strategy based on
     /// generate_random
-    #[cfg(test)]
     fn uniform_keypair_strategy() -> BoxedStrategy<Self> {
         // The no_shrink is because keypairs should be fixed -- shrinking would cause a different
         // keypair to be generated, which appears to not be very useful.
@@ -84,6 +86,10 @@ pub trait KeyPair: Sized + Debug {
             .boxed()
     }
 }
+
+// blanket implementation
+#[cfg(test)]
+impl<KP> KeyPairExt for KP where KP: KeyPair + Debug {}
 
 /// This is a blanket implementation of SizedBytes for any instance of KeyPair
 /// with any length of keys. This encodes that we serialize the public key

--- a/src/tests/opaque_ke_test.rs
+++ b/src/tests/opaque_ke_test.rs
@@ -391,7 +391,7 @@ fn test_r3() -> Result<(), PakeError> {
     .unwrap()
     .finish(
         RegisterSecondMessage::try_from(&parameters.r2[..]).unwrap(),
-        &Key::try_from(parameters.server_s_pk).unwrap(),
+        &Key::try_from(&parameters.server_s_pk[..]).unwrap(),
         &mut finish_registration_rng,
     )
     .unwrap();
@@ -456,7 +456,7 @@ fn test_l2() -> Result<(), PakeError> {
     let mut server_e_sk_rng = CycleRng::new(parameters.server_e_sk);
     let (l2, server_login) = ServerLogin::start::<AesgcmX255193dhNoSlowHash, _>(
         ServerRegistration::try_from(&parameters.password_file[..]).unwrap(),
-        &Key::try_from(parameters.server_s_sk).unwrap(),
+        &Key::try_from(&parameters.server_s_sk[..]).unwrap(),
         LoginFirstMessage::<EdwardsPoint>::try_from(&parameters.l1[..]).unwrap(),
         &mut server_e_sk_rng,
     )
@@ -481,7 +481,7 @@ fn test_l3() -> Result<(), PakeError> {
             .finish(
                 LoginSecondMessage::<Aes256Gcm, EdwardsPoint>::try_from(&parameters.l2[..])
                     .unwrap(),
-                &Key::try_from(parameters.server_s_pk)?,
+                &Key::try_from(&parameters.server_s_pk[..])?,
                 &mut client_e_sk_rng,
             )
             .unwrap();


### PR DESCRIPTION
This groups a few simpler & straightforward  changes originally designed withing the key exchange customization PR, which make sense in the larger context.

Please see the individual commit messages.