### PR TITLE
add deny check to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,3 +37,10 @@ jobs:
         with:
           command: test
           args: --all-features
+
+  deny-check:
+    name: cargo-deny check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: EmbarkStudios/cargo-deny-action@v1


### PR DESCRIPTION
This helps if we run into a package with a cargo-audit advisory, the wrong license, or anything else deny would issue an error on.

Successful run at 
https://github.com/huitseeker/opaque-ke/actions/runs/150799735