### PR TITLE
Pass-through x,curve2559 backends

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,57 @@ on:
     types: [opened, repoened, synchronize]
 
 jobs:
-  combo:
-    name: test + Clippy + rustfmt
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        backend_feature:
+          - u64_backend
+          - u32_backend
+    name: test
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features ${{ matrix.backend_feature }}
+
+  clippy:
+    name: cargo clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
+
+
+  format:
+    name: cargo fmt
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -25,18 +74,6 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
-
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features -- -D warnings
-
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
 
   deny-check:
     name: cargo-deny check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,15 @@ edition = "2018"
 readme = "README.md"
 
 [features]
-default = []
+default = ["u64_backend"]
 slow-hash = ["scrypt"]
 bench = []
+u64_backend = ["curve25519-dalek/u64_backend", "x25519-dalek/u64_backend"]
+u32_backend = ["curve25519-dalek/u32_backend", "x25519-dalek/u32_backend"]
 
 [dependencies]
 aead = "0.3.1"
-curve25519-dalek = "2.1.0"
+curve25519-dalek = { version = "2.1.0", default-features = false, features = ["std"]}
 displaydoc = "0.1"
 generic-array = "0.14.2"
 hkdf = "0.9.0-alpha.0"
@@ -25,7 +27,7 @@ rand_core = "0.5.1"
 scrypt = { version = "0.3.0", optional = true }
 sha2 = "0.9.0"
 thiserror = "1.0.19"
-x25519-dalek = "0.6.0"
+x25519-dalek = { version = "0.6.0", default-features = false, features = ["std"]}
 zeroize = "1.1"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,6 +386,12 @@
 #![cfg_attr(not(feature = "bench"), deny(missing_docs))]
 #![deny(unsafe_code)]
 
+#[cfg(not(any(feature = "u64_backend", feature = "u32_backend",)))]
+compile_error!(
+    "no dalek arithmetic backend cargo feature enabled! \
+     please enable one of: u64_backend, u32_backend"
+);
+
 // Error types
 pub mod errors;
 


### PR DESCRIPTION
Allow building & testing with:
`cargo test --features "u32-backend" --no-default-features`

Successful run with the new CI at https://github.com/huitseeker/opaque-ke/actions/runs/178883098 (ad below)