### PR TITLE
Re-establish `cargo check --all-targets`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ rand = "0.7"
 [[bench]]
 name = "oprf"
 harness = false
+required-features = ["bench"]


### PR DESCRIPTION
The bench in benches/oprf.rs requires a feature to have visibility over private members, and doesn't work without it.
`cargo check --all-targets` is the standard quick way to check code under build & test targets, but does not specify features.

This simply skips the `benches` when the `"bench"` feature it depends on is not activated.