### PR TITLE
Fix benches + run their compilation in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,26 @@ jobs:
           command: test
           args: --no-default-features --features ${{ matrix.backend_feature }}
 
+  benches:
+    name: cargo bench compilation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo bench --no-run
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
+          args: --features "bench" --no-run
+
   clippy:
     name: cargo clippy
     runs-on: ubuntu-latest

--- a/benches/oprf.rs
+++ b/benches/oprf.rs
@@ -15,6 +15,7 @@ use opaque_ke::{
     oprf::{generate_oprf1_shim, generate_oprf2_shim, generate_oprf3_shim, OprfClientBytes},
 };
 use rand::{prelude::ThreadRng, thread_rng};
+use sha2::Sha256;
 
 fn oprf1(c: &mut Criterion) {
     let mut csprng: ThreadRng = thread_rng();
@@ -103,8 +104,8 @@ fn oprf3(c: &mut Criterion) {
 
     c.bench_function("generate_oprf3 with Ristretto", move |b| {
         b.iter(|| {
-            let _res =
-                generate_oprf3_shim::<RistrettoPoint>(input, beta, &blinding_factor).unwrap();
+            let _res = generate_oprf3_shim::<RistrettoPoint, Sha256>(input, beta, &blinding_factor)
+                .unwrap();
         })
     });
 }
@@ -126,7 +127,8 @@ fn oprf3_edwards(c: &mut Criterion) {
 
     c.bench_function("generate_oprf3 with Edwards", move |b| {
         b.iter(|| {
-            let _res = generate_oprf3_shim::<EdwardsPoint>(input, beta, &blinding_factor).unwrap();
+            let _res =
+                generate_oprf3_shim::<EdwardsPoint, Sha256>(input, beta, &blinding_factor).unwrap();
         })
     });
 }

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -78,12 +78,12 @@ pub fn generate_oprf2_shim<G: Group>(
 
 #[cfg(feature = "bench")]
 #[inline]
-pub fn generate_oprf3_shim<G: Group>(
+pub fn generate_oprf3_shim<G: Group, H: Hash>(
     input: &[u8],
     point: G,
     blinding_factor: &G::Scalar,
-) -> Result<GenericArray<u8, U32>, InternalPakeError> {
-    generate_oprf3(input, point, blinding_factor)
+) -> Result<GenericArray<u8, <H as Digest>::OutputSize>, InternalPakeError> {
+    generate_oprf3::<G, H>(input, point, blinding_factor)
 }
 
 // Tests


### PR DESCRIPTION
This should avoid letting our benchmarking code get stale.

https://github.com/huitseeker/opaque-ke/actions/runs/238346044 for a successful run of the new CI.