### PR TITLE
Make KeyExchange generic in KeyFormat

### DIFF
--- a/src/key_exchange/traits.rs
+++ b/src/key_exchange/traits.rs
@@ -6,13 +6,13 @@
 use crate::{
     errors::{InternalPakeError, ProtocolError},
     hash::Hash,
-    keypair::{Key, KeyPair},
+    keypair::KeyPair,
 };
 use rand_core::{CryptoRng, RngCore};
 
 use std::convert::TryFrom;
 
-pub trait KeyExchange<D: Hash, KeyFormat: KeyPair<Repr = Key>> {
+pub trait KeyExchange<D: Hash, KeyFormat: KeyPair> {
     type KE1State: TryFrom<Vec<u8>, Error = InternalPakeError> + ToBytes;
     type KE2State: TryFrom<Vec<u8>, Error = ProtocolError> + ToBytes;
     type KE1Message: TryFrom<Vec<u8>, Error = InternalPakeError> + ToBytes;


### PR DESCRIPTION
Our Key exchange data structures came with a nasty `Repr = Key` constraint that limited the Key formats to be represented with a `Vec<u8>`, and really did not need that constraint. 

This removes it.