### PR TITLE
Remove the last superfluous Repr = Key

### DIFF
--- a/src/ciphersuite.rs
+++ b/src/ciphersuite.rs
@@ -6,12 +6,8 @@
 //! Defines the CipherSuite trait to specify the underlying primitives for OPAQUE
 
 use crate::{
-    errors::InternalPakeError,
-    hash::Hash,
-    key_exchange::traits::KeyExchange,
-    keypair::{Key, KeyPair},
-    map_to_curve::GroupWithMapToCurve,
-    slow_hash::SlowHash,
+    errors::InternalPakeError, hash::Hash, key_exchange::traits::KeyExchange, keypair::KeyPair,
+    map_to_curve::GroupWithMapToCurve, slow_hash::SlowHash,
 };
 
 use rand_core::{CryptoRng, RngCore};
@@ -32,7 +28,7 @@ pub trait CipherSuite {
     /// `map_to_curve::GroupWithMapToCurve`.
     type Group: GroupWithMapToCurve;
     /// A keypair type composed of public and private components
-    type KeyFormat: KeyPair<Repr = Key> + PartialEq;
+    type KeyFormat: KeyPair + PartialEq;
     /// A key exchange protocol
     type KeyExchange: KeyExchange<Self::Hash, Self::KeyFormat>;
     /// The main hash function use (for HKDF computations and hashing transcripts)

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -12,7 +12,7 @@ use crate::{
     group::Group,
     hash::Hash,
     key_exchange::traits::{KeyExchange, ToBytes},
-    keypair::{Key, KeyPair, SizedBytes},
+    keypair::{KeyPair, SizedBytes},
     oprf,
     oprf::OprfClientBytes,
     slow_hash::SlowHash,
@@ -519,7 +519,7 @@ where
         let mut output: Vec<u8> = CS::Group::scalar_as_bytes(&self.oprf_key).to_vec();
         self.client_s_pk
             .iter()
-            .for_each(|v| output.extend_from_slice(&v));
+            .for_each(|v| output.extend_from_slice(&v.to_arr()));
         self.envelope
             .iter()
             .for_each(|v| output.extend_from_slice(&v.to_bytes()));
@@ -794,7 +794,7 @@ impl<CS: CipherSuite> ClientLogin<CS> {
             l2.ke2_message,
             &self.ke1_state,
             server_s_pk.clone(),
-            Key::from_bytes(&opened_envelope.plaintext)?,
+            <CS::KeyFormat as KeyPair>::Repr::from_bytes(&opened_envelope.plaintext)?,
         )?;
 
         Ok((
@@ -869,7 +869,7 @@ impl<CS: CipherSuite> ServerLogin<CS> {
     /// ```
     pub fn start<R: RngCore + CryptoRng>(
         password_file: ServerRegistration<CS>,
-        server_s_sk: &Key,
+        server_s_sk: &<CS::KeyFormat as KeyPair>::Repr,
         l1: LoginFirstMessage<CS>,
         rng: &mut R,
     ) -> Result<ServerLoginStartResult<CS>, ProtocolError> {


### PR DESCRIPTION
This required purgin the usage of the low-level Key access, but now we
should be able to replace the Key type piecemeal, like a proper generic type.