### PR TITLE
Adding documentation for advanced usage + optional parameters

### DIFF
--- a/src/tests/opaque_ke_test.rs
+++ b/src/tests/opaque_ke_test.rs
@@ -593,10 +593,6 @@ fn test_credential_response() -> Result<(), ProtocolError> {
         hex::encode(server_login_start_result.plain_info),
     );
     assert_eq!(
-        hex::encode(&parameters.client_s_pk),
-        hex::encode(server_login_start_result.client_s_pk),
-    );
-    assert_eq!(
         hex::encode(&parameters.credential_response),
         hex::encode(server_login_start_result.message.serialize())
     );
@@ -636,7 +632,7 @@ fn test_key_exchange() -> Result<(), ProtocolError> {
     );
     assert_eq!(
         hex::encode(&parameters.server_s_pk),
-        hex::encode(&client_login_finish_result.server_s_pk)
+        hex::encode(&client_login_finish_result.server_s_pk.to_arr().to_vec())
     );
     assert_eq!(
         hex::encode(&parameters.shared_secret),


### PR DESCRIPTION
To be landed after #108 (since it is a dependency). This adds documentation for the result structs and all of the "advanced features", namely:
- usage of the shared secret
- export key
- checking server_s_pk
- custom identifiers
- plain_info and confidential_info in key exchange

Addresses #107 and #97 