### PR TITLE
Addressing various TODOs and minor cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,12 +390,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
-name = "fiat-crypto"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6ab97095615857b6ad00a8330fff0e443f1def9fd357cef82d0ca0677b616b"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,7 +607,6 @@ dependencies = [
  "curve25519-dalek",
  "digest",
  "displaydoc",
- "fiat-crypto",
  "generic-array",
  "generic-bytes",
  "generic-bytes-derive",
@@ -630,7 +623,6 @@ dependencies = [
  "sha2",
  "subtle",
  "thiserror",
- "x25519-dalek",
  "zeroize",
 ]
 
@@ -1024,18 +1016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,33 +1236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "x25519-dalek"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
-dependencies = [
- "curve25519-dalek",
- "rand_core",
- "zeroize",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,13 @@ readme = "README.md"
 default = ["u64_backend"]
 slow-hash = ["scrypt"]
 bench = []
-u64_backend = ["curve25519-dalek/u64_backend", "x25519-dalek/u64_backend"]
-u32_backend = ["curve25519-dalek/u32_backend", "x25519-dalek/u32_backend"]
+u64_backend = ["curve25519-dalek/u64_backend"]
+u32_backend = ["curve25519-dalek/u32_backend"]
 
 [dependencies]
 curve25519-dalek = { version = "3.0.0", default-features = false, features = ["std"] }
 digest = "0.9.0"
 displaydoc = "0.1.7"
-fiat-crypto = { version = "0.1.5"}
 generic-array = "0.14.4"
 generic-bytes = { version = "0.1.0" }
 generic-bytes-derive = { version = "0.1.0" }
@@ -28,10 +27,8 @@ hkdf = "0.10.0"
 hmac = "0.10.1"
 rand_core = "0.5.1"
 scrypt = { version = "0.5.0", optional = true }
-sha2 = "0.9.2"
 subtle = { version = "2.3.0", default-features = false }
 thiserror = "1.0.22"
-x25519-dalek = { version = "1.1.0", default-features = false, features = ["std"] }
 zeroize = "1.1.1"
 
 [dev-dependencies]
@@ -42,6 +39,7 @@ criterion = "0.3.3"
 hex = "0.4.2"
 lazy_static = "1.4.0"
 serde_json = "1.0.60"
+sha2 = "0.9.2"
 proptest = "0.10.1"
 rand = "0.7"
 rustyline = "7.0.0"

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -100,6 +100,9 @@ pub(crate) struct Envelope<D: Hash> {
     hmac: GenericArray<u8, <D as Digest>::OutputSize>,
 }
 
+// Note that this struct represents an envelope that has been "opened" with the asssociated
+// key. This key is also used to derive the export_key parameter, which is technically
+// unrelated to the envelope's encrypted and authenticated contents.
 pub(crate) struct OpenedEnvelope<D: Hash> {
     pub(crate) client_s_sk: Vec<u8>,
     pub(crate) export_key: GenericArray<u8, <D as Digest>::OutputSize>,

--- a/src/key_exchange/traits.rs
+++ b/src/key_exchange/traits.rs
@@ -21,7 +21,6 @@ pub trait KeyExchange<D: Hash, G: Group> {
     type KE3Message: for<'r> TryFrom<&'r [u8], Error = PakeError> + ToBytes;
 
     fn generate_ke1<R: RngCore + CryptoRng>(
-        l1_component: Vec<u8>,
         info: Vec<u8>,
         rng: &mut R,
     ) -> Result<(Self::KE1State, Self::KE1Message), ProtocolError>;
@@ -44,6 +43,7 @@ pub trait KeyExchange<D: Hash, G: Group> {
         l2_component: Vec<u8>,
         ke2_message: Self::KE2Message,
         ke1_state: &Self::KE1State,
+        serialized_credential_request: &[u8],
         server_s_pk: Key,
         client_s_sk: Key,
         id_u: Vec<u8>,

--- a/src/map_to_curve.rs
+++ b/src/map_to_curve.rs
@@ -37,7 +37,6 @@ impl GroupWithMapToCurve for RistrettoPoint {
     // Implements the hash_to_ristretto255() function from
     // https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-10.txt
     fn map_to_curve<H: Hash>(msg: &[u8], dst: &[u8]) -> Result<Self, InternalPakeError> {
-        // FIXME use generic_array and turn this into a compile-time error if size mismatch
         let uniform_bytes =
             expand_message_xmd::<H>(msg, dst, <H as Digest>::OutputSize::to_usize())?;
         Ok(<Self as Group>::hash_to_curve(

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -259,12 +259,24 @@ pub struct CredentialResponse<CS: CipherSuite> {
 impl<CS: CipherSuite> CredentialResponse<CS> {
     /// Serialization into bytes
     pub fn serialize(&self) -> Vec<u8> {
-        let mut credential_response: Vec<u8> = Vec::new();
-        credential_response.extend_from_slice(&self.beta.to_arr());
-        credential_response.extend_from_slice(&serialize(&self.server_s_pk.to_arr().to_vec(), 2));
-        credential_response.extend_from_slice(&self.envelope.to_bytes());
-        credential_response.extend_from_slice(&self.ke2_message.to_bytes());
-        credential_response
+        [
+            Self::serialize_without_ke(&self.beta, &self.server_s_pk, &self.envelope),
+            self.ke2_message.to_bytes(),
+        ]
+        .concat()
+    }
+
+    pub(crate) fn serialize_without_ke(
+        beta: &CS::Group,
+        server_s_pk: &Key,
+        envelope: &Envelope<CS::Hash>,
+    ) -> Vec<u8> {
+        [
+            &beta.to_arr(),
+            &serialize(&server_s_pk.to_arr().to_vec(), 2)[..],
+            &envelope.to_bytes(),
+        ]
+        .concat()
     }
 
     /// Deserialization from bytes

--- a/src/serialization/mod.rs
+++ b/src/serialization/mod.rs
@@ -22,7 +22,6 @@ pub(crate) fn i2osp(input: usize, length: usize) -> Vec<u8> {
 // Corresponds to the OS2IP() function from RFC8017
 pub(crate) fn os2ip(input: &[u8]) -> Result<usize, PakeError> {
     if input.len() > std::mem::size_of::<usize>() {
-        // TODO:: check RFC compliance in refusing this
         return Err(PakeError::SerializationError);
     }
 


### PR DESCRIPTION
- Removing use of NONCE_SIZE and using NonceLen type instead
- Fixing digital locker example
- Modularizing the serialization of various messages when used in AKE section

Closes #124 and #126 