### PR TITLE
Exporting rand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,7 +589,6 @@ dependencies = [
  "lazy_static",
  "proptest",
  "rand 0.8.3",
- "rand_core 0.6.1",
  "rustyline",
  "scrypt",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ generic-bytes = { version = "0.1.0" }
 generic-bytes-derive = { version = "0.1.0" }
 hkdf = "0.10.0"
 hmac = "0.10.1"
-rand_core = { version = "0.6.0", features = ["getrandom"] }
+rand = "0.8.3"
 scrypt = { version = "0.5.0", optional = true }
 subtle = { version = "2.3.0", default-features = false }
 thiserror = "1.0.22"
@@ -41,7 +41,6 @@ lazy_static = "1.4.0"
 serde_json = "1.0.60"
 sha2 = "0.9.2"
 proptest = "0.10.1"
-rand = "0.8"
 rustyline = "7.0.0"
 
 [[bench]]

--- a/examples/digital_locker.rs
+++ b/examples/digital_locker.rs
@@ -26,17 +26,18 @@
 
 use chacha20poly1305::aead::{Aead, NewAead};
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
-use rand_core::{OsRng, RngCore};
 use rustyline::error::ReadlineError;
 use rustyline::Editor;
 use std::convert::TryFrom;
 use std::process::exit;
 
 use opaque_ke::{
-    ciphersuite::CipherSuite, ClientLogin, ClientLoginFinishParameters, ClientLoginStartParameters,
-    ClientRegistration, ClientRegistrationFinishParameters, CredentialFinalization,
-    CredentialRequest, CredentialResponse, RegistrationRequest, RegistrationResponse,
-    RegistrationUpload, ServerLogin, ServerLoginStartParameters, ServerRegistration,
+    ciphersuite::CipherSuite,
+    rand::{rngs::OsRng, RngCore},
+    ClientLogin, ClientLoginFinishParameters, ClientLoginStartParameters, ClientRegistration,
+    ClientRegistrationFinishParameters, CredentialFinalization, CredentialRequest,
+    CredentialResponse, RegistrationRequest, RegistrationResponse, RegistrationUpload, ServerLogin,
+    ServerLoginStartParameters, ServerRegistration,
 };
 
 // The ciphersuite trait allows to specify the underlying primitives

--- a/examples/simple_login.rs
+++ b/examples/simple_login.rs
@@ -20,7 +20,6 @@
 //! messages over "the wire" to the server. These bytes are serialized
 //! and explicitly annotated in the below functions.
 
-use rand_core::OsRng;
 use rustyline::error::ReadlineError;
 use rustyline::Editor;
 use std::collections::HashMap;
@@ -28,10 +27,11 @@ use std::convert::TryFrom;
 use std::process::exit;
 
 use opaque_ke::{
-    ciphersuite::CipherSuite, ClientLogin, ClientLoginFinishParameters, ClientLoginStartParameters,
-    ClientRegistration, ClientRegistrationFinishParameters, CredentialFinalization,
-    CredentialRequest, CredentialResponse, RegistrationRequest, RegistrationResponse,
-    RegistrationUpload, ServerLogin, ServerLoginStartParameters, ServerRegistration,
+    ciphersuite::CipherSuite, rand::rngs::OsRng, ClientLogin, ClientLoginFinishParameters,
+    ClientLoginStartParameters, ClientRegistration, ClientRegistrationFinishParameters,
+    CredentialFinalization, CredentialRequest, CredentialResponse, RegistrationRequest,
+    RegistrationResponse, RegistrationUpload, ServerLogin, ServerLoginStartParameters,
+    ServerRegistration,
 };
 
 // The ciphersuite trait allows to specify the underlying primitives

--- a/src/ciphersuite.rs
+++ b/src/ciphersuite.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use digest::Digest;
 
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 
 /// Configures the underlying primitives used in OPAQUE
 /// * `Group`: a finite cyclic group along with a point representation, along

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -12,7 +12,7 @@ use digest::Digest;
 use generic_array::{typenum::Unsigned, GenericArray};
 use hkdf::Hkdf;
 use hmac::{Hmac, Mac, NewMac};
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 use std::convert::TryFrom;
 
 // Constant string used as salt for HKDF computation
@@ -318,7 +318,7 @@ pub(crate) fn mode_from_ids(optional_ids: &Option<(Vec<u8>, Vec<u8>)>) -> InnerE
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand_core::OsRng;
+    use rand::rngs::OsRng;
 
     #[test]
     fn seal_and_open() {

--- a/src/group.rs
+++ b/src/group.rs
@@ -19,7 +19,7 @@ use generic_array::{
 };
 use std::convert::TryInto;
 
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 use std::ops::Mul;
 use zeroize::Zeroize;
 

--- a/src/key_exchange/traits.rs
+++ b/src/key_exchange/traits.rs
@@ -9,7 +9,7 @@ use crate::{
     hash::Hash,
     keypair::Key,
 };
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 
 use std::convert::TryFrom;
 

--- a/src/key_exchange/tripledh.rs
+++ b/src/key_exchange/tripledh.rs
@@ -23,7 +23,7 @@ use generic_array::{
 use generic_bytes::SizedBytes;
 use hkdf::Hkdf;
 use hmac::{Hmac, Mac, NewMac};
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 
 use std::convert::TryFrom;
 

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -14,13 +14,14 @@ use generic_bytes_derive::TryFromForSizedBytes;
 use proptest::prelude::*;
 #[cfg(test)]
 use rand::{rngs::StdRng, SeedableRng};
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::ops::Deref;
 
-// Pub(crate) convenience extension trait of SizedBytes for our purposes
-pub(crate) trait SizedBytesExt: SizedBytes {
+/// Convenience extension trait of SizedBytes
+pub trait SizedBytesExt: SizedBytes {
+    /// Convert from bytes
     fn from_bytes(bytes: &[u8]) -> Result<Self, TryFromSizedBytesError> {
         <Self as SizedBytes>::from_arr(GenericArray::from_slice(bytes))
     }
@@ -118,7 +119,7 @@ impl<G: Group + Debug> KeyPair<G> {
     }
 }
 
-/// A minimalist key type built around [u8;32]
+/// A minimalist key type built around a \[u8; 32\]
 #[derive(Debug, PartialEq, Eq, Clone, TryFromForSizedBytes)]
 #[ErrorType = "::generic_bytes::TryFromSizedBytesError"]
 #[repr(transparent)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 //! #     type Hash = sha2::Sha512;
 //! #     type SlowHash = opaque_ke::slow_hash::NoOpHash;
 //! # }
-//! use rand_core::{OsRng, RngCore};
+//! use rand::{rngs::OsRng, RngCore};
 //! let mut rng = OsRng;
 //! let server_kp = Default::generate_random_keypair(&mut rng);
 //! # Ok::<(), ProtocolError>(())
@@ -80,7 +80,7 @@
 //! #     type SlowHash = opaque_ke::slow_hash::NoOpHash;
 //! # }
 //! use opaque_ke::ClientRegistration;
-//! use rand_core::{OsRng, RngCore};
+//! use rand::{rngs::OsRng, RngCore};
 //! let mut client_rng = OsRng;
 //! let client_registration_start_result = ClientRegistration::<Default>::start(
 //!     &mut client_rng,
@@ -109,7 +109,7 @@
 //! #     type Hash = sha2::Sha512;
 //! #     type SlowHash = opaque_ke::slow_hash::NoOpHash;
 //! # }
-//! # use rand_core::{OsRng, RngCore};
+//! # use rand::{rngs::OsRng, RngCore};
 //! # let mut client_rng = OsRng;
 //! # let client_registration_start_result = ClientRegistration::<Default>::start(
 //! #     &mut client_rng,
@@ -146,7 +146,7 @@
 //! #     type Hash = sha2::Sha512;
 //! #     type SlowHash = opaque_ke::slow_hash::NoOpHash;
 //! # }
-//! # use rand_core::{OsRng, RngCore};
+//! # use rand::{rngs::OsRng, RngCore};
 //! # let mut client_rng = OsRng;
 //! # let client_registration_start_result = ClientRegistration::<Default>::start(
 //! #     &mut client_rng,
@@ -184,7 +184,7 @@
 //! #     type Hash = sha2::Sha512;
 //! #     type SlowHash = opaque_ke::slow_hash::NoOpHash;
 //! # }
-//! # use rand_core::{OsRng, RngCore};
+//! # use rand::{rngs::OsRng, RngCore};
 //! # let mut client_rng = OsRng;
 //! # let client_registration_start_result = ClientRegistration::<Default>::start(
 //! #     &mut client_rng,
@@ -225,7 +225,7 @@
 //! #     type Hash = sha2::Sha512;
 //! #     type SlowHash = opaque_ke::slow_hash::NoOpHash;
 //! # }
-//! # use rand_core::{OsRng, RngCore};
+//! # use rand::{rngs::OsRng, RngCore};
 //! use opaque_ke::{ClientLogin, ClientLoginStartParameters};
 //! let mut client_rng = OsRng;
 //! let client_login_start_result = ClientLogin::<Default>::start(
@@ -258,7 +258,7 @@
 //! #     type Hash = sha2::Sha512;
 //! #     type SlowHash = opaque_ke::slow_hash::NoOpHash;
 //! # }
-//! # use rand_core::{OsRng, RngCore};
+//! # use rand::{rngs::OsRng, RngCore};
 //! # let mut client_rng = OsRng;
 //! # let client_registration_start_result = ClientRegistration::<Default>::start(
 //! #     &mut client_rng,
@@ -307,7 +307,7 @@
 //! #     type Hash = sha2::Sha512;
 //! #     type SlowHash = opaque_ke::slow_hash::NoOpHash;
 //! # }
-//! # use rand_core::{OsRng, RngCore};
+//! # use rand::{rngs::OsRng, RngCore};
 //! # let mut client_rng = OsRng;
 //! # let client_registration_start_result = ClientRegistration::<Default>::start(
 //! #     &mut client_rng,
@@ -354,7 +354,7 @@
 //! #     type Hash = sha2::Sha512;
 //! #     type SlowHash = opaque_ke::slow_hash::NoOpHash;
 //! # }
-//! # use rand_core::{OsRng, RngCore};
+//! # use rand::{rngs::OsRng, RngCore};
 //! # let mut client_rng = OsRng;
 //! # let client_registration_start_result = ClientRegistration::<Default>::start(
 //! #     &mut client_rng,
@@ -430,7 +430,7 @@
 //! #     type Hash = sha2::Sha512;
 //! #     type SlowHash = opaque_ke::slow_hash::NoOpHash;
 //! # }
-//! # use rand_core::{OsRng, RngCore};
+//! # use rand::{rngs::OsRng, RngCore};
 //! # let mut client_rng = OsRng;
 //! # let client_registration_start_result = ClientRegistration::<Default>::start(
 //! #     &mut client_rng,
@@ -507,7 +507,7 @@
 //! #     type Hash = sha2::Sha512;
 //! #     type SlowHash = opaque_ke::slow_hash::NoOpHash;
 //! # }
-//! # use rand_core::{OsRng, RngCore};
+//! # use rand::{rngs::OsRng, RngCore};
 //! # let mut client_rng = OsRng;
 //! # let client_registration_start_result = ClientRegistration::<Default>::start(
 //! #     &mut client_rng,
@@ -572,7 +572,7 @@
 //! #     type Hash = sha2::Sha512;
 //! #     type SlowHash = opaque_ke::slow_hash::NoOpHash;
 //! # }
-//! # use rand_core::{OsRng, RngCore};
+//! # use rand::{rngs::OsRng, RngCore};
 //! # let mut client_rng = OsRng;
 //! # let client_registration_start_result = ClientRegistration::<Default>::start(
 //! #     &mut client_rng,
@@ -607,7 +607,7 @@
 //! #     type Hash = sha2::Sha512;
 //! #     type SlowHash = opaque_ke::slow_hash::NoOpHash;
 //! # }
-//! # use rand_core::{OsRng, RngCore};
+//! # use rand::{rngs::OsRng, RngCore};
 //! # let mut client_rng = OsRng;
 //! # let client_registration_start_result = ClientRegistration::<Default>::start(
 //! #     &mut client_rng,
@@ -655,7 +655,7 @@
 //! #     type Hash = sha2::Sha512;
 //! #     type SlowHash = opaque_ke::slow_hash::NoOpHash;
 //! # }
-//! # use rand_core::{OsRng, RngCore};
+//! # use rand::{rngs::OsRng, RngCore};
 //! # let mut client_rng = OsRng;
 //! # let client_registration_start_result = ClientRegistration::<Default>::start(
 //! #     &mut client_rng,
@@ -748,6 +748,8 @@ mod serialization;
 mod tests;
 
 // Exports
+
+pub use rand;
 
 pub use crate::messages::{
     CredentialFinalization, CredentialRequest, CredentialResponse, RegistrationRequest,

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -23,7 +23,7 @@ use crate::{
 use digest::Digest;
 use generic_array::{typenum::Unsigned, GenericArray};
 use generic_bytes::SizedBytes;
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 use std::{convert::TryFrom, marker::PhantomData};
 use zeroize::Zeroize;
 
@@ -112,7 +112,7 @@ impl<CS: CipherSuite> ClientRegistration<CS> {
     /// ```
     /// use opaque_ke::ClientRegistration;
     /// # use opaque_ke::errors::ProtocolError;
-    /// use rand_core::{OsRng, RngCore};
+    /// use rand::{rngs::OsRng, RngCore};
     /// use opaque_ke::ciphersuite::CipherSuite;
     /// struct Default;
     /// impl CipherSuite for Default {
@@ -160,7 +160,7 @@ impl<CS: CipherSuite> ClientRegistration<CS> {
     /// use opaque_ke::{ClientRegistration, ClientRegistrationFinishParameters, ServerRegistration};
     /// # use opaque_ke::errors::ProtocolError;
     /// # use opaque_ke::keypair::KeyPair;
-    /// use rand_core::{OsRng, RngCore};
+    /// use rand::{rngs::OsRng, RngCore};
     /// use opaque_ke::ciphersuite::CipherSuite;
     /// struct Default;
     /// impl CipherSuite for Default {
@@ -318,7 +318,7 @@ impl<CS: CipherSuite> ServerRegistration<CS> {
     /// ```
     /// use opaque_ke::*;
     /// # use opaque_ke::errors::ProtocolError;
-    /// use rand_core::{OsRng, RngCore};
+    /// use rand::{rngs::OsRng, RngCore};
     /// use opaque_ke::ciphersuite::CipherSuite;
     /// struct Default;
     /// impl CipherSuite for Default {
@@ -369,7 +369,7 @@ impl<CS: CipherSuite> ServerRegistration<CS> {
     /// ```
     /// use opaque_ke::{*, keypair::KeyPair};
     /// # use opaque_ke::errors::ProtocolError;
-    /// use rand_core::{OsRng, RngCore};
+    /// use rand::{rngs::OsRng, RngCore};
     /// use opaque_ke::ciphersuite::CipherSuite;
     /// struct Default;
     /// impl CipherSuite for Default {
@@ -518,7 +518,7 @@ impl<CS: CipherSuite> ClientLogin<CS> {
     /// ```
     /// use opaque_ke::{ClientLogin, ClientLoginStartParameters};
     /// # use opaque_ke::errors::ProtocolError;
-    /// use rand_core::{OsRng, RngCore};
+    /// use rand::{rngs::OsRng, RngCore};
     /// use opaque_ke::ciphersuite::CipherSuite;
     /// struct Default;
     /// impl CipherSuite for Default {
@@ -568,7 +568,7 @@ impl<CS: CipherSuite> ClientLogin<CS> {
     /// # use opaque_ke::{ClientRegistration, ClientRegistrationFinishParameters, ServerRegistration};
     /// # use opaque_ke::errors::ProtocolError;
     /// # use opaque_ke::keypair::KeyPair;
-    /// use rand_core::{OsRng, RngCore};
+    /// use rand::{rngs::OsRng, RngCore};
     /// use opaque_ke::ciphersuite::CipherSuite;
     /// struct Default;
     /// impl CipherSuite for Default {
@@ -723,7 +723,7 @@ impl<CS: CipherSuite> ServerLogin<CS> {
     /// # use opaque_ke::{ClientRegistration, ClientRegistrationFinishParameters, ServerRegistration};
     /// # use opaque_ke::errors::ProtocolError;
     /// # use opaque_ke::keypair::KeyPair;
-    /// use rand_core::{OsRng, RngCore};
+    /// use rand::{rngs::OsRng, RngCore};
     /// use opaque_ke::ciphersuite::CipherSuite;
     /// struct Default;
     /// impl CipherSuite for Default {
@@ -828,7 +828,7 @@ impl<CS: CipherSuite> ServerLogin<CS> {
     /// # use opaque_ke::{ClientRegistration, ClientRegistrationFinishParameters, ServerRegistration};
     /// # use opaque_ke::errors::ProtocolError;
     /// # use opaque_ke::keypair::KeyPair;
-    /// use rand_core::{OsRng, RngCore};
+    /// use rand::{rngs::OsRng, RngCore};
     /// use opaque_ke::ciphersuite::CipherSuite;
     /// struct Default;
     /// impl CipherSuite for Default {

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use digest::Digest;
 use generic_array::GenericArray;
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 
 /// Used to store the OPRF input and blinding factor
 pub struct Token<Grp: Group> {
@@ -117,7 +117,7 @@ mod tests {
     use crate::group::Group;
     use curve25519_dalek::ristretto::RistrettoPoint;
     use generic_array::{arr, GenericArray};
-    use rand_core::OsRng;
+    use rand::rngs::OsRng;
     use sha2::Sha512;
 
     fn prf(input: &[u8], oprf_key: &[u8; 32]) -> GenericArray<u8, <Sha512 as Digest>::OutputSize> {

--- a/src/serialization/tests.rs
+++ b/src/serialization/tests.rs
@@ -20,7 +20,7 @@ use curve25519_dalek::ristretto::RistrettoPoint;
 use generic_array::typenum::Unsigned;
 use generic_bytes::SizedBytes;
 use proptest::{collection::vec, prelude::*};
-use rand_core::{OsRng, RngCore};
+use rand::{rngs::OsRng, RngCore};
 
 use sha2::Digest;
 use std::convert::TryFrom;

--- a/src/tests/full_test.rs
+++ b/src/tests/full_test.rs
@@ -17,7 +17,7 @@ use crate::{
 use curve25519_dalek::ristretto::RistrettoPoint;
 use generic_array::typenum::Unsigned;
 use generic_bytes::SizedBytes;
-use rand_core::{OsRng, RngCore};
+use rand::{rngs::OsRng, RngCore};
 use serde_json::Value;
 use std::convert::TryFrom;
 

--- a/src/tests/mock_rng.rs
+++ b/src/tests/mock_rng.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use rand_core::{CryptoRng, Error, RngCore};
+use rand::{CryptoRng, Error, RngCore};
 use std::cmp::min;
 
 /// A simple implementation of `RngCore` for testing purposes.


### PR DESCRIPTION
This will allow for applications to use the rand library paired with opaque-ke, since the top-level API requires rand parameters anyway, and will hopefully make it more convenient for a wrapper protocol to sync with opaque without worrying about rand version incompatibilities.