### PR TITLE
Converting to_bytes and try_from to serialize() and deserialize()

### DIFF
--- a/examples/digital_locker.rs
+++ b/examples/digital_locker.rs
@@ -28,7 +28,6 @@ use chacha20poly1305::aead::{Aead, NewAead};
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 use rustyline::error::ReadlineError;
 use rustyline::Editor;
-use std::convert::TryFrom;
 use std::process::exit;
 
 use opaque_ke::{
@@ -129,7 +128,7 @@ fn register_locker(
 
     Locker {
         contents: ciphertext,
-        password_file: password_file.to_bytes(),
+        password_file: password_file.serialize(),
     }
 }
 
@@ -150,7 +149,8 @@ fn open_locker(
 
     // Client sends credential_request_bytes to server
 
-    let password_file = ServerRegistration::<Default>::try_from(&locker.password_file[..]).unwrap();
+    let password_file =
+        ServerRegistration::<Default>::deserialize(&locker.password_file[..]).unwrap();
     let mut server_rng = OsRng;
     let server_login_start_result = ServerLogin::start(
         &mut server_rng,

--- a/examples/simple_login.rs
+++ b/examples/simple_login.rs
@@ -23,7 +23,6 @@
 use rustyline::error::ReadlineError;
 use rustyline::Editor;
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::process::exit;
 
 use opaque_ke::{
@@ -84,7 +83,7 @@ fn account_registration(
         .state
         .finish(RegistrationUpload::deserialize(&message_bytes[..]).unwrap())
         .unwrap();
-    password_file.to_bytes()
+    password_file.serialize()
 }
 
 // Password-based login between a client and server
@@ -104,7 +103,7 @@ fn account_login(
 
     // Client sends credential_request_bytes to server
 
-    let password_file = ServerRegistration::<Default>::try_from(password_file_bytes).unwrap();
+    let password_file = ServerRegistration::<Default>::deserialize(password_file_bytes).unwrap();
     let mut server_rng = OsRng;
     let server_login_start_result = ServerLogin::start(
         &mut server_rng,

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -113,11 +113,6 @@ pub(crate) struct OpenedInnerEnvelope<D: Hash> {
 }
 
 impl<D: Hash> Envelope<D> {
-    /// The additional number of bytes added to the plaintext
-    pub(crate) fn additional_size() -> usize {
-        NONCE_LEN + <D as Digest>::OutputSize::to_usize()
-    }
-
     fn hmac_key_size() -> usize {
         <D as Digest>::OutputSize::to_usize()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@
 //! a [ServerRegistration] from the second step.
 //! The server runs [ServerRegistration::finish] to produce a finalized [ServerRegistration].
 //! At this point, the client can be considered as successfully registered, and the server can invoke
-//! [ServerRegistration::to_bytes] to store the password file for use during the login protocol.
+//! [ServerRegistration::serialize] to store the password file for use during the login protocol.
 //! ```
 //! # use opaque_ke::{
 //! #   errors::ProtocolError,
@@ -268,15 +268,14 @@
 //! # let server_kp = Default::generate_random_keypair(&mut server_rng);
 //! # let server_registration_start_result = ServerRegistration::<Default>::start(&mut server_rng, client_registration_start_result.message, server_kp.public())?;
 //! # let client_registration_finish_result = client_registration_start_result.state.finish(&mut client_rng, server_registration_start_result.message, ClientRegistrationFinishParameters::default())?;
-//! # let password_file_bytes = server_registration_start_result.state.finish(client_registration_finish_result.message)?.to_bytes();
+//! # let password_file_bytes = server_registration_start_result.state.finish(client_registration_finish_result.message)?.serialize();
 //! # let client_login_start_result = ClientLogin::<Default>::start(
 //! #   &mut client_rng,
 //! #   b"password",
 //! #   ClientLoginStartParameters::default(),
 //! # )?;
 //! use opaque_ke::{ServerLogin, ServerLoginStartParameters};
-//! use std::convert::TryFrom;
-//! let password_file = ServerRegistration::<Default>::try_from(&password_file_bytes[..])?;
+//! let password_file = ServerRegistration::<Default>::deserialize(&password_file_bytes[..])?;
 //! let mut server_rng = OsRng;
 //! let server_login_start_result = ServerLogin::start(
 //!     &mut server_rng,
@@ -317,15 +316,14 @@
 //! # let server_kp = Default::generate_random_keypair(&mut server_rng);
 //! # let server_registration_start_result = ServerRegistration::<Default>::start(&mut server_rng, client_registration_start_result.message, server_kp.public())?;
 //! # let client_registration_finish_result = client_registration_start_result.state.finish(&mut client_rng, server_registration_start_result.message, ClientRegistrationFinishParameters::default())?;
-//! # let password_file_bytes = server_registration_start_result.state.finish(client_registration_finish_result.message)?.to_bytes();
+//! # let password_file_bytes = server_registration_start_result.state.finish(client_registration_finish_result.message)?.serialize();
 //! # let client_login_start_result = ClientLogin::<Default>::start(
 //! #     &mut client_rng,
 //! #     b"password",
 //! #     ClientLoginStartParameters::default(),
 //! # )?;
-//! # use std::convert::TryFrom;
 //! # let password_file =
-//! #   ServerRegistration::<Default>::try_from(
+//! #   ServerRegistration::<Default>::deserialize(
 //! #     &password_file_bytes[..],
 //! #   )?;
 //! # let server_login_start_result =
@@ -364,15 +362,14 @@
 //! # let server_kp = Default::generate_random_keypair(&mut server_rng);
 //! # let server_registration_start_result = ServerRegistration::<Default>::start(&mut server_rng, client_registration_start_result.message, server_kp.public())?;
 //! # let client_registration_finish_result = client_registration_start_result.state.finish(&mut client_rng, server_registration_start_result.message, ClientRegistrationFinishParameters::default())?;
-//! # let password_file_bytes = server_registration_start_result.state.finish(client_registration_finish_result.message)?.to_bytes();
+//! # let password_file_bytes = server_registration_start_result.state.finish(client_registration_finish_result.message)?.serialize();
 //! # let client_login_start_result = ClientLogin::<Default>::start(
 //! #   &mut client_rng,
 //! #   b"password",
 //! #   ClientLoginStartParameters::default(),
 //! # )?;
-//! # use std::convert::TryFrom;
 //! # let password_file =
-//! #   ServerRegistration::<Default>::try_from(
+//! #   ServerRegistration::<Default>::deserialize(
 //! #     &password_file_bytes[..],
 //! #   )?;
 //! # let server_login_start_result =
@@ -444,15 +441,14 @@
 //! // During setup or registration, the server transmits its static public key to the client
 //! let server_s_pk = server_kp.public(); // obtained from the server
 //! # let client_registration_finish_result = client_registration_start_result.state.finish(&mut client_rng, server_registration_start_result.message, ClientRegistrationFinishParameters::default())?;
-//! # let password_file_bytes = server_registration_start_result.state.finish(client_registration_finish_result.message)?.to_bytes();
+//! # let password_file_bytes = server_registration_start_result.state.finish(client_registration_finish_result.message)?.serialize();
 //! # let client_login_start_result = ClientLogin::<Default>::start(
 //! #     &mut client_rng,
 //! #     b"password",
 //! #     ClientLoginStartParameters::default(),
 //! # )?;
-//! # use std::convert::TryFrom;
 //! # let password_file =
-//! #   ServerRegistration::<Default>::try_from(
+//! #   ServerRegistration::<Default>::deserialize(
 //! #     &password_file_bytes[..],
 //! #   )?;
 //! # let server_login_start_result =
@@ -522,15 +518,14 @@
 //!     server_registration_start_result.message,
 //!     ClientRegistrationFinishParameters::default()
 //! )?;
-//! # let password_file_bytes = server_registration_start_result.state.finish(client_registration_finish_result.message)?.to_bytes();
+//! # let password_file_bytes = server_registration_start_result.state.finish(client_registration_finish_result.message)?.serialize();
 //! # let client_login_start_result = ClientLogin::<Default>::start(
 //! #     &mut client_rng,
 //! #     b"password",
 //! #     ClientLoginStartParameters::default(),
 //! # )?;
-//! # use std::convert::TryFrom;
 //! # let password_file =
-//! #   ServerRegistration::<Default>::try_from(
+//! #   ServerRegistration::<Default>::deserialize(
 //! #     &password_file_bytes[..],
 //! #   )?;
 //! # let server_login_start_result =
@@ -617,15 +612,14 @@
 //! # let server_kp = Default::generate_random_keypair(&mut server_rng);
 //! # let server_registration_start_result = ServerRegistration::<Default>::start(&mut server_rng, client_registration_start_result.message, server_kp.public())?;
 //! # let client_registration_finish_result = client_registration_start_result.state.finish(&mut client_rng, server_registration_start_result.message, ClientRegistrationFinishParameters::WithIdentifiers(b"username".to_vec(), b"facebook.com".to_vec()))?;
-//! # let password_file_bytes = server_registration_start_result.state.finish(client_registration_finish_result.message)?.to_bytes();
+//! # let password_file_bytes = server_registration_start_result.state.finish(client_registration_finish_result.message)?.serialize();
 //! # let client_login_start_result = ClientLogin::<Default>::start(
 //! #   &mut client_rng,
 //! #   b"password",
 //! #   ClientLoginStartParameters::default(),
 //! # )?;
 //! # use opaque_ke::{ServerLogin, ServerLoginStartParameters};
-//! # use std::convert::TryFrom;
-//! # let password_file = ServerRegistration::<Default>::try_from(&password_file_bytes[..])?;
+//! # let password_file = ServerRegistration::<Default>::deserialize(&password_file_bytes[..])?;
 //! # let mut server_rng = OsRng;
 //! let server_login_start_result = ServerLogin::start(
 //!     &mut server_rng,
@@ -665,15 +659,14 @@
 //! # let server_kp = Default::generate_random_keypair(&mut server_rng);
 //! # let server_registration_start_result = ServerRegistration::<Default>::start(&mut server_rng, client_registration_start_result.message, server_kp.public())?;
 //! # let client_registration_finish_result = client_registration_start_result.state.finish(&mut client_rng, server_registration_start_result.message, ClientRegistrationFinishParameters::WithIdentifiers(b"username".to_vec(), b"facebook.com".to_vec()))?;
-//! # let password_file_bytes = server_registration_start_result.state.finish(client_registration_finish_result.message)?.to_bytes();
+//! # let password_file_bytes = server_registration_start_result.state.finish(client_registration_finish_result.message)?.serialize();
 //! # let client_login_start_result = ClientLogin::<Default>::start(
 //! #     &mut client_rng,
 //! #     b"password",
 //! #     ClientLoginStartParameters::default(),
 //! # )?;
-//! # use std::convert::TryFrom;
 //! # let password_file =
-//! #   ServerRegistration::<Default>::try_from(
+//! #   ServerRegistration::<Default>::deserialize(
 //! #     &password_file_bytes[..],
 //! #   )?;
 //! # let server_login_start_result =

--- a/src/serialization/tests.rs
+++ b/src/serialization/tests.rs
@@ -58,8 +58,8 @@ fn client_registration_roundtrip() {
 
     // serialization order: scalar, password
     let bytes: Vec<u8> = [&sc.as_bytes()[..], &pw[..]].concat();
-    let reg = ClientRegistration::<Default>::try_from(&bytes[..]).unwrap();
-    let reg_bytes = reg.to_bytes();
+    let reg = ClientRegistration::<Default>::deserialize(&bytes[..]).unwrap();
+    let reg_bytes = reg.serialize();
     assert_eq!(reg_bytes, bytes);
 }
 
@@ -71,8 +71,8 @@ fn server_registration_roundtrip() {
     let oprf_key = <RistrettoPoint as Group>::random_scalar(&mut rng);
     let mut oprf_bytes: Vec<u8> = vec![];
     oprf_bytes.extend_from_slice(oprf_key.as_bytes());
-    let reg = ServerRegistration::<Default>::try_from(&oprf_bytes[..]).unwrap();
-    let reg_bytes = reg.to_bytes();
+    let reg = ServerRegistration::<Default>::deserialize(&oprf_bytes[..]).unwrap();
+    let reg_bytes = reg.serialize();
     assert_eq!(reg_bytes, oprf_bytes);
     // If we do have envelope and client pk, the server registration contains
     // the whole kit
@@ -90,8 +90,8 @@ fn server_registration_roundtrip() {
     bytes.extend_from_slice(oprf_key.as_bytes());
     bytes.extend_from_slice(&mock_client_kp.public().to_arr());
     bytes.extend_from_slice(&mock_envelope_bytes);
-    let reg = ServerRegistration::<Default>::try_from(&bytes[..]).unwrap();
-    let reg_bytes = reg.to_bytes();
+    let reg = ServerRegistration::<Default>::deserialize(&bytes[..]).unwrap();
+    let reg_bytes = reg.serialize();
     assert_eq!(reg_bytes, bytes);
 }
 
@@ -279,8 +279,8 @@ fn client_login_roundtrip() {
         &pw[..],
     ]
     .concat();
-    let reg = ClientLogin::<Default>::try_from(&bytes[..]).unwrap();
-    let reg_bytes = reg.to_bytes();
+    let reg = ClientLogin::<Default>::deserialize(&bytes[..]).unwrap();
+    let reg_bytes = reg.serialize();
     assert_eq!(reg_bytes, bytes);
 }
 
@@ -359,52 +359,52 @@ fn test_i2osp_os2ip(bytes in vec(any::<u8>(), 0..std::mem::size_of::<usize>())) 
 
 #[test]
 fn test_nocrash_register_first_message(bytes in vec(any::<u8>(), 0..200)) {
-    RegistrationRequest::<Default>::try_from(&bytes[..]).map_or(true, |_| true);
+    RegistrationRequest::<Default>::deserialize(&bytes[..]).map_or(true, |_| true);
 }
 
 #[test]
 fn test_nocrash_register_second_message(bytes in vec(any::<u8>(), 0..200)) {
-    RegistrationResponse::<Default>::try_from(&bytes[..]).map_or(true, |_| true);
+    RegistrationResponse::<Default>::deserialize(&bytes[..]).map_or(true, |_| true);
 }
 
 #[test]
 fn test_nocrash_register_third_message(bytes in vec(any::<u8>(), 0..200)) {
-    RegistrationUpload::<Default>::try_from(&bytes[..]).map_or(true, |_| true);
+    RegistrationUpload::<Default>::deserialize(&bytes[..]).map_or(true, |_| true);
 }
 
 #[test]
 fn test_nocrash_login_first_message(bytes in vec(any::<u8>(), 0..500)) {
-    CredentialRequest::<Default>::try_from(&bytes[..]).map_or(true, |_| true);
+    CredentialRequest::<Default>::deserialize(&bytes[..]).map_or(true, |_| true);
 }
 
 #[test]
 fn test_nocrash_login_second_message(bytes in vec(any::<u8>(), 0..500)) {
-    CredentialResponse::<Default>::try_from(&bytes[..]).map_or(true, |_| true);
+    CredentialResponse::<Default>::deserialize(&bytes[..]).map_or(true, |_| true);
 }
 
 #[test]
 fn test_nocrash_login_third_message(bytes in vec(any::<u8>(), 0..500)) {
-    CredentialFinalization::<Default>::try_from(&bytes[..]).map_or(true, |_| true);
+    CredentialFinalization::<Default>::deserialize(&bytes[..]).map_or(true, |_| true);
 }
 
 #[test]
 fn test_nocrash_client_registration(bytes in vec(any::<u8>(), 0..700)) {
-    ClientRegistration::<Default>::try_from(&bytes[..]).map_or(true, |_| true);
+    ClientRegistration::<Default>::deserialize(&bytes[..]).map_or(true, |_| true);
 }
 
 #[test]
 fn test_nocrash_server_registration(bytes in vec(any::<u8>(), 0..700)) {
-    ServerRegistration::<Default>::try_from(&bytes[..]).map_or(true, |_| true);
+    ServerRegistration::<Default>::deserialize(&bytes[..]).map_or(true, |_| true);
 }
 
 #[test]
 fn test_nocrash_client_login(bytes in vec(any::<u8>(), 0..700)) {
-    ClientLogin::<Default>::try_from(&bytes[..]).map_or(true, |_| true);
+    ClientLogin::<Default>::deserialize(&bytes[..]).map_or(true, |_| true);
 }
 
 #[test]
 fn test_nocrash_server_login(bytes in vec(any::<u8>(), 0..700)) {
-    ServerLogin::<Default>::try_from(&bytes[..]).map_or(true, |_| true);
+    ServerLogin::<Default>::deserialize(&bytes[..]).map_or(true, |_| true);
 }
 
 }

--- a/src/tests/opaque_test_vectors.rs
+++ b/src/tests/opaque_test_vectors.rs
@@ -354,7 +354,7 @@ fn get_password_file_bytes(parameters: &TestVectorParameters) -> Result<Vec<u8>,
         .state
         .finish(RegistrationUpload::deserialize(&parameters.registration_upload[..]).unwrap())?;
 
-    Ok(password_file.to_bytes())
+    Ok(password_file.serialize())
 }
 
 #[test]
@@ -463,7 +463,7 @@ fn test_ke2() -> Result<(), ProtocolError> {
             CycleRng::new([parameters.server_private_keyshare, parameters.server_nonce].concat());
         let server_login_start_result = ServerLogin::<Ristretto255Sha512NoSlowHash>::start(
             &mut server_private_keyshare_and_nonce_rng,
-            ServerRegistration::try_from(&password_file_bytes[..]).unwrap(),
+            ServerRegistration::deserialize(&password_file_bytes[..]).unwrap(),
             &Key::try_from(&parameters.server_private_key[..]).unwrap(),
             CredentialRequest::<Ristretto255Sha512NoSlowHash>::deserialize(&parameters.KE1[..])
                 .unwrap(),
@@ -527,7 +527,7 @@ fn test_ke3() -> Result<(), ProtocolError> {
         );
         assert_eq!(
             hex::encode(&parameters.KE3),
-            hex::encode(client_login_finish_result.message.to_bytes())
+            hex::encode(client_login_finish_result.message.serialize())
         );
         assert_eq!(
             hex::encode(&parameters.export_key),
@@ -546,7 +546,7 @@ fn test_server_login_finish() -> Result<(), ProtocolError> {
             CycleRng::new([parameters.server_private_keyshare, parameters.server_nonce].concat());
         let server_login_start_result = ServerLogin::<Ristretto255Sha512NoSlowHash>::start(
             &mut server_private_keyshare_and_nonce_rng,
-            ServerRegistration::try_from(&password_file_bytes[..]).unwrap(),
+            ServerRegistration::deserialize(&password_file_bytes[..]).unwrap(),
             &Key::try_from(&parameters.server_private_key[..]).unwrap(),
             CredentialRequest::<Ristretto255Sha512NoSlowHash>::deserialize(&parameters.KE1[..])
                 .unwrap(),
@@ -563,7 +563,7 @@ fn test_server_login_finish() -> Result<(), ProtocolError> {
 
         let server_login_result = server_login_start_result
             .state
-            .finish(CredentialFinalization::try_from(&parameters.KE3[..])?)?;
+            .finish(CredentialFinalization::deserialize(&parameters.KE3[..])?)?;
 
         assert_eq!(
             hex::encode(parameters.session_key),


### PR DESCRIPTION
It is more convenient if all top-level functions use the same name for serialization/deserialization, rather than some of them supporting to_bytes / try_from.

Closes #135 