### PR TITLE
Updating to 0.5 and removing generic_bytes_derive dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,6 @@ name: Rust CI
 on:
   push:
     branches:
-      - tls
       - master
   pull_request:
     types: [opened, repoened, synchronize]
@@ -16,16 +15,19 @@ jobs:
         backend_feature:
           - u64_backend
           - u32_backend
+        toolchain:
+          - nightly
+          - 1.41.0
     name: test
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install nightly toolchain
+      - name: Install ${{ matrix.toolchain }} toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: ${{ matrix.toolchain }}
           override: true
           components: rustfmt, clippy
 
@@ -75,6 +77,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      matrix:
+        toolchain:
+          - nightly
+          - 1.41.0
     name: test simple_login command-line example
     steps:
       - name: install expect
@@ -85,7 +91,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: ${{ matrix.toolchain }}
           override: true
           components: rustfmt, clippy
       - name: Run expect (which then runs cargo run)
@@ -95,6 +101,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      matrix:
+        toolchain:
+          - nightly
+          - 1.41.0
     name: test digital_locker command-line example
     steps:
       - name: install expect
@@ -105,7 +115,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: ${{ matrix.toolchain }}
           override: true
           components: rustfmt, clippy
       - name: Run expect (which then runs cargo run)
@@ -118,7 +128,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install nightly toolchain
+      - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 (March 1, 2020)
+
+* Removed dependency on generic-bytes-derive package
+
 ## 0.4.0 (February 26, 2020)
 
 * Adherence to protocol format described in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,12 @@ checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -218,7 +224,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -228,7 +234,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -239,7 +245,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "const_fn",
  "crossbeam-utils",
  "lazy_static",
@@ -254,7 +260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -314,11 +320,11 @@ dependencies = [
 
 [[package]]
 name = "dirs-next"
-version = "2.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+checksum = "cf36e65a80337bea855cd4ef9b8401ffce06a7baedf2e85ec467b1ac3f6e82b6"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -357,16 +363,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,23 +382,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-bytes-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4257fe99e64e321c197164da8ae22f7a3c074a5b2519072866e2d38bc1ca59e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -413,7 +398,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
@@ -510,7 +495,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -530,13 +515,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.19.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
+checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
 ]
 
@@ -573,7 +558,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opaque-ke"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -584,7 +569,6 @@ dependencies = [
  "displaydoc",
  "generic-array",
  "generic-bytes",
- "generic-bytes-derive",
  "hex",
  "hkdf",
  "hmac",
@@ -887,14 +871,12 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "7.1.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8227301bfc717136f0ecbd3d064ba8199e44497a0bdd46bb01ede4387cfd2cec"
+checksum = "6f0d5e7b0219a3eadd5439498525d4765c59b7c993ef0c12244865cd2d988413"
 dependencies = [
- "bitflags",
- "cfg-if",
+ "cfg-if 0.1.10",
  "dirs-next",
- "fs2",
  "libc",
  "log",
  "memchr",
@@ -1012,7 +994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpuid-bool 0.1.2",
  "digest",
  "opaque-debug",
@@ -1041,7 +1023,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "rand 0.8.3",
  "redox_syscall",
@@ -1172,7 +1154,7 @@ version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opaque-ke"
-version = "0.4.0"
+version = "0.5.0"
 repository = "https://github.com/novifinancial/opaque-ke"
 keywords = ["cryptography", "crypto", "opaque", "passwords", "authentication"]
 description = "An implementation of the OPAQUE password-authenticated key exchange protocol"
@@ -22,7 +22,6 @@ digest = "0.9.0"
 displaydoc = "0.1.7"
 generic-array = "0.14.4"
 generic-bytes = { version = "0.1.0" }
-generic-bytes-derive = { version = "0.1.0" }
 hkdf = "0.10.0"
 hmac = "0.10.1"
 rand = "0.8"
@@ -41,7 +40,7 @@ lazy_static = "1.4.0"
 serde_json = "1.0.60"
 sha2 = "0.9.2"
 proptest = "0.10.1"
-rustyline = "7.0.0"
+rustyline = "6.3.0"
 
 [[bench]]
 name = "oprf"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Installation
 Add the following line to the dependencies of your `Cargo.toml`:
 
 ```
-opaque-ke = "0.4.0"
+opaque-ke = "0.5.0"
 ```
 
 Resources

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -9,7 +9,6 @@ use crate::errors::InternalPakeError;
 use crate::group::Group;
 use generic_array::{typenum::U32, GenericArray};
 use generic_bytes::{SizedBytes, TryFromSizedBytesError};
-use generic_bytes_derive::TryFromForSizedBytes;
 #[cfg(test)]
 use proptest::prelude::*;
 #[cfg(test)]
@@ -120,8 +119,7 @@ impl<G: Group + Debug> KeyPair<G> {
 }
 
 /// A minimalist key type built around a \[u8; 32\]
-#[derive(Debug, PartialEq, Eq, Clone, TryFromForSizedBytes)]
-#[ErrorType = "::generic_bytes::TryFromSizedBytesError"]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[repr(transparent)]
 pub struct Key(Vec<u8>);
 

--- a/src/tests/opaque_test_vectors.rs
+++ b/src/tests/opaque_test_vectors.rs
@@ -4,12 +4,17 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{
-    ciphersuite::CipherSuite, errors::*, key_exchange::tripledh::TripleDH, keypair::Key, opaque::*,
-    slow_hash::NoOpHash, tests::mock_rng::CycleRng, *,
+    ciphersuite::CipherSuite,
+    errors::*,
+    key_exchange::tripledh::TripleDH,
+    keypair::{Key, SizedBytesExt},
+    opaque::*,
+    slow_hash::NoOpHash,
+    tests::mock_rng::CycleRng,
+    *,
 };
 use curve25519_dalek::ristretto::RistrettoPoint;
 use serde_json::Value;
-use std::convert::TryFrom;
 
 // Tests
 // =====
@@ -351,7 +356,7 @@ fn get_password_file_bytes(parameters: &TestVectorParameters) -> Result<Vec<u8>,
         ServerRegistration::<Ristretto255Sha512NoSlowHash>::start(
             &mut oprf_key_rng,
             RegistrationRequest::deserialize(&parameters.registration_request[..]).unwrap(),
-            &Key::try_from(&parameters.server_public_key[..]).unwrap(),
+            &Key::from_bytes(&parameters.server_public_key[..]).unwrap(),
         )?;
 
     let password_file = server_registration_start_result
@@ -386,7 +391,7 @@ fn test_registration_response() -> Result<(), ProtocolError> {
             ServerRegistration::<Ristretto255Sha512NoSlowHash>::start(
                 &mut oprf_key_rng,
                 RegistrationRequest::deserialize(&parameters.registration_request[..]).unwrap(),
-                &Key::try_from(&parameters.server_public_key[..]).unwrap(),
+                &Key::from_bytes(&parameters.server_public_key[..]).unwrap(),
             )?;
         assert_eq!(
             hex::encode(parameters.registration_response),
@@ -468,7 +473,7 @@ fn test_ke2() -> Result<(), ProtocolError> {
         let server_login_start_result = ServerLogin::<Ristretto255Sha512NoSlowHash>::start(
             &mut server_private_keyshare_and_nonce_rng,
             ServerRegistration::deserialize(&password_file_bytes[..]).unwrap(),
-            &Key::try_from(&parameters.server_private_key[..]).unwrap(),
+            &Key::from_bytes(&parameters.server_private_key[..]).unwrap(),
             CredentialRequest::<Ristretto255Sha512NoSlowHash>::deserialize(&parameters.KE1[..])
                 .unwrap(),
             if parameters.envelope_mode == EnvelopeMode::CustomIdentifier {
@@ -551,7 +556,7 @@ fn test_server_login_finish() -> Result<(), ProtocolError> {
         let server_login_start_result = ServerLogin::<Ristretto255Sha512NoSlowHash>::start(
             &mut server_private_keyshare_and_nonce_rng,
             ServerRegistration::deserialize(&password_file_bytes[..]).unwrap(),
-            &Key::try_from(&parameters.server_private_key[..]).unwrap(),
+            &Key::from_bytes(&parameters.server_private_key[..]).unwrap(),
             CredentialRequest::<Ristretto255Sha512NoSlowHash>::deserialize(&parameters.KE1[..])
                 .unwrap(),
             if parameters.envelope_mode == EnvelopeMode::CustomIdentifier {


### PR DESCRIPTION
Closes https://github.com/novifinancial/opaque-ke/issues/149

Also updates the github actions to check for compatibility against Rust v1.41.0