### PR TITLE
Zeroize keys on drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,6 +1016,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,3 +1258,18 @@ name = "zeroize"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rand = "0.8"
 scrypt = { version = "0.5.0", optional = true }
 subtle = { version = "2.3.0", default-features = false }
 thiserror = "1.0.22"
-zeroize = "1.1.1"
+zeroize = { version = "1.1.1", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 anyhow = "1.0.35"

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -121,6 +121,8 @@ impl<G: Group + Debug> KeyPair<G> {
 
 /// A minimalist key type built around a \[u8; 32\]
 #[derive(Debug, PartialEq, Eq, Clone, Zeroize)]
+// Ensure Key material is zeroed after use.
+#[zeroize(drop)]
 #[repr(transparent)]
 pub struct Key(Vec<u8>);
 

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -17,6 +17,7 @@ use rand::{CryptoRng, RngCore};
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::ops::Deref;
+use zeroize::Zeroize;
 
 /// Convenience extension trait of SizedBytes
 pub trait SizedBytesExt: SizedBytes {
@@ -30,7 +31,7 @@ pub trait SizedBytesExt: SizedBytes {
 impl<T> SizedBytesExt for T where T: SizedBytes {}
 
 /// A Keypair trait with public-private verification
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Zeroize)]
 pub struct KeyPair<G> {
     pk: Key,
     sk: Key,
@@ -119,7 +120,7 @@ impl<G: Group + Debug> KeyPair<G> {
 }
 
 /// A minimalist key type built around a \[u8; 32\]
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Zeroize)]
 #[repr(transparent)]
 pub struct Key(Vec<u8>);
 


### PR DESCRIPTION
Currently the main key structure is not zeroized on drop. This diff adds this best practice functionality.