### PR TITLE
Implement serde serialization/deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +571,7 @@ version = "0.5.1-pre.1"
 dependencies = [
  "anyhow",
  "base64",
+ "bincode",
  "chacha20poly1305",
  "criterion",
  "curve25519-dalek",
@@ -577,6 +587,7 @@ dependencies = [
  "rand 0.8.3",
  "rustyline",
  "scrypt",
+ "serde",
  "serde_json",
  "sha2",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,15 @@ edition = "2018"
 readme = "README.md"
 
 [features]
-default = ["u64_backend"]
+default = ["u64_backend", "serialize"]
 slow-hash = ["scrypt"]
 bench = []
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
+serialize = ["serde", "base64"]
 
 [dependencies]
+base64 = { version = "0.13", optional = true }
 curve25519-dalek = { version = "3.0.0", default-features = false, features = ["std"] }
 digest = "0.9.0"
 displaydoc = "0.1.7"
@@ -26,6 +28,7 @@ hkdf = "0.10.0"
 hmac = "0.10.1"
 rand = "0.8"
 scrypt = { version = "0.5.0", optional = true }
+serde = { version = "1", optional = true }
 subtle = { version = "2.3.0", default-features = false }
 thiserror = "1.0.22"
 zeroize = { version = "1.1.1", features = ["zeroize_derive"] }
@@ -33,6 +36,7 @@ zeroize = { version = "1.1.1", features = ["zeroize_derive"] }
 [dev-dependencies]
 anyhow = "1.0.35"
 base64 = "0.13.0"
+bincode = "1"
 chacha20poly1305 = "0.7.1"
 criterion = "0.3.3"
 hex = "0.4.2"

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -13,6 +13,7 @@ use crate::{
         PakeError, ProtocolError,
     },
     group::Group,
+    impl_serialize_and_deserialize_for,
     key_exchange::traits::{KeyExchange, ToBytes},
     keypair::{Key, KeyPair, SizedBytesExt},
 };
@@ -47,6 +48,8 @@ impl<CS: CipherSuite> RegistrationRequest<CS> {
     }
 }
 
+impl_serialize_and_deserialize_for!(RegistrationRequest);
+
 /// The answer sent by the server to the user, upon reception of the
 /// registration attempt
 pub struct RegistrationResponse<CS: CipherSuite> {
@@ -80,6 +83,8 @@ impl<CS: CipherSuite> RegistrationResponse<CS> {
         })
     }
 }
+
+impl_serialize_and_deserialize_for!(RegistrationResponse);
 
 /// The final message from the client, containing sealed cryptographic
 /// identifiers
@@ -122,6 +127,8 @@ impl<CS: CipherSuite> RegistrationUpload<CS> {
     }
 }
 
+impl_serialize_and_deserialize_for!(RegistrationUpload);
+
 /// The message sent by the user to the server, to initiate registration
 pub struct CredentialRequest<CS: CipherSuite> {
     /// blinded password information
@@ -158,6 +165,8 @@ impl<CS: CipherSuite> CredentialRequest<CS> {
         Ok(Self { alpha, ke1_message })
     }
 }
+
+impl_serialize_and_deserialize_for!(CredentialRequest);
 
 /// The answer sent by the server to the user, upon reception of the
 /// login attempt
@@ -229,6 +238,8 @@ impl<CS: CipherSuite> CredentialResponse<CS> {
     }
 }
 
+impl_serialize_and_deserialize_for!(CredentialResponse);
+
 /// The answer sent by the client to the server, upon reception of the
 /// sealed envelope
 pub struct CredentialFinalization<CS: CipherSuite> {
@@ -248,3 +259,5 @@ impl<CS: CipherSuite> CredentialFinalization<CS> {
         Ok(Self { ke3_message })
     }
 }
+
+impl_serialize_and_deserialize_for!(CredentialFinalization);

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -11,6 +11,7 @@ use crate::{
     errors::{utils::check_slice_size_atleast, InternalPakeError, PakeError, ProtocolError},
     group::Group,
     hash::Hash,
+    impl_serialize_and_deserialize_for,
     key_exchange::traits::{KeyExchange, ToBytesWithPointers},
     keypair::{Key, KeyPair, SizedBytesExt},
     map_to_curve::GroupWithMapToCurve,
@@ -82,6 +83,8 @@ impl<CS: CipherSuite> ClientRegistration<CS> {
         ]
     }
 }
+
+impl_serialize_and_deserialize_for!(ClientRegistration);
 
 /// Optional parameters for client registration finish
 pub enum ClientRegistrationFinishParameters {
@@ -385,6 +388,8 @@ impl<CS: CipherSuite> ServerRegistration<CS> {
     }
 }
 
+impl_serialize_and_deserialize_for!(ServerRegistration);
+
 // Login
 // =====
 
@@ -453,6 +458,8 @@ impl<CS: CipherSuite> ClientLogin<CS> {
         ].concat()
     }
 }
+
+impl_serialize_and_deserialize_for!(ClientLogin);
 
 /// Optional parameters for client login start
 pub enum ClientLoginStartParameters {
@@ -879,6 +886,8 @@ impl<CS: CipherSuite> ServerLogin<CS> {
         self.ke2_state.as_byte_ptrs()
     }
 }
+
+impl_serialize_and_deserialize_for!(ServerLogin);
 
 // Zeroize on drop implementations
 

--- a/src/tests/full_test.rs
+++ b/src/tests/full_test.rs
@@ -450,6 +450,43 @@ fn test_registration_request() -> Result<(), ProtocolError> {
     Ok(())
 }
 
+#[cfg(feature = "serialize")]
+#[test]
+fn test_serialization() -> Result<(), ProtocolError> {
+    let parameters = populate_test_vectors(&serde_json::from_str(TEST_VECTOR).unwrap());
+    let mut rng = CycleRng::new(parameters.blinding_factor.to_vec());
+    let client_registration_start_result =
+        ClientRegistration::<RistrettoSha5123dhNoSlowHash>::start(&mut rng, &parameters.password)?;
+    {
+        // Test the json serialization (human-readable, base64).
+        let registration_request_json =
+            serde_json::to_string(&client_registration_start_result.message).unwrap();
+        assert_eq!(
+            registration_request_json,
+            r#""FLqG5TAYzlUH0r+y2YrT9g4wLYJr/zQQpexmnI4e8X0=""#
+        );
+        let registration_request: RegistrationRequest<RistrettoSha5123dhNoSlowHash> =
+            serde_json::from_str(&registration_request_json).unwrap();
+        assert_eq!(
+            hex::encode(client_registration_start_result.message.serialize()),
+            hex::encode(registration_request.serialize()),
+        );
+    }
+    {
+        // Test the bincode serialization (binary).
+        let registration_request_bin =
+            bincode::serialize(&client_registration_start_result.message).unwrap();
+        assert_eq!(registration_request_bin.len(), 40);
+        let registration_request: RegistrationRequest<RistrettoSha5123dhNoSlowHash> =
+            bincode::deserialize(&registration_request_bin).unwrap();
+        assert_eq!(
+            hex::encode(client_registration_start_result.message.serialize()),
+            hex::encode(registration_request.serialize()),
+        );
+    }
+    Ok(())
+}
+
 #[test]
 fn test_registration_response() -> Result<(), ProtocolError> {
     let parameters = populate_test_vectors(&serde_json::from_str(TEST_VECTOR).unwrap());


### PR DESCRIPTION
This makes it much easier to pass the messages as part of protocols, and provides a standard interface for serializing/deserializing all the messages (e.g. to store in DB).

Fixes https://github.com/novifinancial/opaque-ke/issues/166