### PR TITLE
Implement Clone for every message type

### DIFF
--- a/src/key_exchange/traits.rs
+++ b/src/key_exchange/traits.rs
@@ -14,11 +14,11 @@ use rand::{CryptoRng, RngCore};
 use zeroize::Zeroize;
 
 pub trait KeyExchange<D: Hash, G: Group> {
-    type KE1State: FromBytes + ToBytesWithPointers + Zeroize;
-    type KE2State: FromBytes + ToBytesWithPointers + Zeroize;
-    type KE1Message: FromBytes + ToBytes;
-    type KE2Message: FromBytes + ToBytes;
-    type KE3Message: FromBytes + ToBytes;
+    type KE1State: FromBytes + ToBytesWithPointers + Zeroize + Clone;
+    type KE2State: FromBytes + ToBytesWithPointers + Zeroize + Clone;
+    type KE1Message: FromBytes + ToBytes + Clone;
+    type KE2Message: FromBytes + ToBytes + Clone;
+    type KE3Message: FromBytes + ToBytes + Clone;
 
     fn generate_ke1<R: RngCore + CryptoRng>(
         info: Vec<u8>,

--- a/src/key_exchange/tripledh.rs
+++ b/src/key_exchange/tripledh.rs
@@ -237,7 +237,7 @@ impl<D: Hash, G: Group> KeyExchange<D, G> for TripleDH {
 }
 
 /// The client state produced after the first key exchange message
-#[derive(PartialEq, Eq, Zeroize)]
+#[derive(PartialEq, Eq, Zeroize, Clone)]
 #[zeroize(drop)]
 pub struct Ke1State {
     client_e_sk: Key,
@@ -245,7 +245,7 @@ pub struct Ke1State {
 }
 
 /// The first key exchange message
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct Ke1Message {
     pub(crate) client_nonce: GenericArray<u8, NonceLen>,
     pub(crate) info: Vec<u8>,
@@ -317,6 +317,7 @@ impl FromBytes for Ke1Message {
     }
 }
 /// The server state produced after the second key exchange message
+#[derive(Clone)]
 pub struct Ke2State<HashLen: ArrayLength<u8>> {
     km3: GenericArray<u8, HashLen>,
     hashed_transcript: GenericArray<u8, HashLen>,
@@ -359,6 +360,7 @@ impl<HashLen: ArrayLength<u8>> ToBytesWithPointers for Ke2State<HashLen> {
 }
 
 /// The second key exchange message
+#[derive(Clone)]
 pub struct Ke2Message<HashLen: ArrayLength<u8>> {
     server_nonce: GenericArray<u8, NonceLen>,
     server_e_pk: Key,
@@ -446,6 +448,7 @@ type TripleDHDerivationResult<D> = (
 );
 
 /// The third key exchange message
+#[derive(Clone)]
 pub struct Ke3Message<HashLen: ArrayLength<u8>> {
     mac: GenericArray<u8, HashLen>,
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -28,6 +28,13 @@ pub struct RegistrationRequest<CS: CipherSuite> {
     pub(crate) alpha: CS::Group,
 }
 
+// Cannot be derived because it would require for CS to be Clone.
+impl<CS: CipherSuite> Clone for RegistrationRequest<CS> {
+    fn clone(&self) -> Self {
+        Self { alpha: self.alpha }
+    }
+}
+
 impl<CS: CipherSuite> RegistrationRequest<CS> {
     /// Serialization into bytes
     pub fn serialize(&self) -> Vec<u8> {
@@ -55,6 +62,16 @@ pub struct RegistrationResponse<CS: CipherSuite> {
     pub(crate) beta: CS::Group,
     /// Server's static public key
     pub(crate) server_s_pk: Vec<u8>,
+}
+
+// Cannot be derived because it would require for CS to be Clone.
+impl<CS: CipherSuite> Clone for RegistrationResponse<CS> {
+    fn clone(&self) -> Self {
+        Self {
+            beta: self.beta,
+            server_s_pk: self.server_s_pk.clone(),
+        }
+    }
 }
 
 impl<CS: CipherSuite> RegistrationResponse<CS> {
@@ -92,6 +109,16 @@ pub struct RegistrationUpload<CS: CipherSuite> {
     pub(crate) envelope: Envelope<CS::Hash>,
     /// The user's public key
     pub(crate) client_s_pk: Key,
+}
+
+// Cannot be derived because it would require for CS to be Clone.
+impl<CS: CipherSuite> Clone for RegistrationUpload<CS> {
+    fn clone(&self) -> Self {
+        Self {
+            envelope: self.envelope.clone(),
+            client_s_pk: self.client_s_pk.clone(),
+        }
+    }
 }
 
 impl<CS: CipherSuite> RegistrationUpload<CS> {
@@ -134,6 +161,16 @@ pub struct CredentialRequest<CS: CipherSuite> {
     pub(crate) ke1_message: <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE1Message,
 }
 
+// Cannot be derived because it would require for CS to be Clone.
+impl<CS: CipherSuite> Clone for CredentialRequest<CS> {
+    fn clone(&self) -> Self {
+        Self {
+            alpha: self.alpha,
+            ke1_message: self.ke1_message.clone(),
+        }
+    }
+}
+
 impl<CS: CipherSuite> CredentialRequest<CS> {
     /// Serialization into bytes
     pub fn serialize(&self) -> Vec<u8> {
@@ -171,6 +208,18 @@ pub struct CredentialResponse<CS: CipherSuite> {
     /// the user's sealed information,
     pub(crate) envelope: Envelope<CS::Hash>,
     pub(crate) ke2_message: <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE2Message,
+}
+
+// Cannot be derived because it would require for CS to be Clone.
+impl<CS: CipherSuite> Clone for CredentialResponse<CS> {
+    fn clone(&self) -> Self {
+        Self {
+            beta: self.beta,
+            server_s_pk: self.server_s_pk.clone(),
+            envelope: self.envelope.clone(),
+            ke2_message: self.ke2_message.clone(),
+        }
+    }
 }
 
 impl<CS: CipherSuite> CredentialResponse<CS> {
@@ -238,6 +287,15 @@ impl_serialize_and_deserialize_for!(CredentialResponse);
 /// sealed envelope
 pub struct CredentialFinalization<CS: CipherSuite> {
     pub(crate) ke3_message: <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE3Message,
+}
+
+// Cannot be derived because it would require for CS to be Clone.
+impl<CS: CipherSuite> Clone for CredentialFinalization<CS> {
+    fn clone(&self) -> Self {
+        Self {
+            ke3_message: self.ke3_message.clone(),
+        }
+    }
 }
 
 impl<CS: CipherSuite> CredentialFinalization<CS> {

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -36,6 +36,15 @@ pub struct ClientRegistration<CS: CipherSuite> {
     pub(crate) token: oprf::Token<CS::Group>,
 }
 
+// Cannot be derived because it would require for CS to be Clone.
+impl<CS: CipherSuite> Clone for ClientRegistration<CS> {
+    fn clone(&self) -> Self {
+        Self {
+            token: self.token.clone(),
+        }
+    }
+}
+
 impl<CS: CipherSuite> ClientRegistration<CS> {
     /// Serialization into bytes
     pub fn serialize(&self) -> Vec<u8> {
@@ -86,6 +95,7 @@ impl<CS: CipherSuite> ClientRegistration<CS> {
 impl_serialize_and_deserialize_for!(ClientRegistration);
 
 /// Optional parameters for client registration finish
+#[derive(Clone)]
 pub enum ClientRegistrationFinishParameters {
     /// Specifying the identifiers idU and idS (corresponding to custom identifier mode)
     WithIdentifiers(Vec<u8>, Vec<u8>),
@@ -105,6 +115,16 @@ pub struct ClientRegistrationStartResult<CS: CipherSuite> {
     pub message: RegistrationRequest<CS>,
     /// The client state that must be persisted in order to complete registration
     pub state: ClientRegistration<CS>,
+}
+
+// Cannot be derived because it would require for CS to be Clone.
+impl<CS: CipherSuite> Clone for ClientRegistrationStartResult<CS> {
+    fn clone(&self) -> Self {
+        Self {
+            message: self.message.clone(),
+            state: self.state.clone(),
+        }
+    }
 }
 
 impl<CS: CipherSuite> ClientRegistration<CS> {
@@ -153,6 +173,18 @@ pub struct ClientRegistrationFinishResult<CS: CipherSuite> {
     /// Instance of the ClientRegistration, only used in tests for checking zeroize
     #[cfg(test)]
     pub state: ClientRegistration<CS>,
+}
+
+// Cannot be derived because it would require for CS to be Clone.
+impl<CS: CipherSuite> Clone for ClientRegistrationFinishResult<CS> {
+    fn clone(&self) -> Self {
+        Self {
+            message: self.message.clone(),
+            export_key: self.export_key.clone(),
+            #[cfg(test)]
+            state: self.state.clone(),
+        }
+    }
 }
 
 impl<CS: CipherSuite> ClientRegistration<CS> {
@@ -230,11 +262,32 @@ pub struct ServerRegistrationStartResult<CS: CipherSuite> {
     pub state: ServerRegistration<CS>,
 }
 
+// Cannot be derived because it would require for CS to be Clone.
+impl<CS: CipherSuite> Clone for ServerRegistrationStartResult<CS> {
+    fn clone(&self) -> Self {
+        Self {
+            message: self.message.clone(),
+            state: self.state.clone(),
+        }
+    }
+}
+
 /// The state elements the server holds to record a registration
 pub struct ServerRegistration<CS: CipherSuite> {
     envelope: Option<Envelope<CS::Hash>>,
     client_s_pk: Option<Key>,
     pub(crate) oprf_key: <CS::Group as Group>::Scalar,
+}
+
+// Cannot be derived because it would require for CS to be Clone.
+impl<CS: CipherSuite> Clone for ServerRegistration<CS> {
+    fn clone(&self) -> Self {
+        Self {
+            envelope: self.envelope.clone(),
+            client_s_pk: self.client_s_pk.clone(),
+            oprf_key: self.oprf_key.clone(),
+        }
+    }
 }
 
 impl<CS: CipherSuite> ServerRegistration<CS> {
@@ -400,6 +453,17 @@ pub struct ClientLogin<CS: CipherSuite> {
     serialized_credential_request: Vec<u8>,
 }
 
+// Cannot be derived because it would require for CS to be Clone.
+impl<CS: CipherSuite> Clone for ClientLogin<CS> {
+    fn clone(&self) -> Self {
+        Self {
+            token: self.token.clone(),
+            ke1_state: self.ke1_state.clone(),
+            serialized_credential_request: self.serialized_credential_request.clone(),
+        }
+    }
+}
+
 impl<CS: CipherSuite> ClientLogin<CS> {
     /// Serialization into bytes
     pub fn serialize(&self) -> Vec<u8> {
@@ -462,6 +526,7 @@ impl<CS: CipherSuite> ClientLogin<CS> {
 impl_serialize_and_deserialize_for!(ClientLogin);
 
 /// Optional parameters for client login start
+#[derive(Clone)]
 pub enum ClientLoginStartParameters {
     /// Specifying a plaintext info field that will be sent to the server
     WithInfo(Vec<u8>),
@@ -481,7 +546,18 @@ pub struct ClientLoginStartResult<CS: CipherSuite> {
     pub state: ClientLogin<CS>,
 }
 
+// Cannot be derived because it would require for CS to be Clone.
+impl<CS: CipherSuite> Clone for ClientLoginStartResult<CS> {
+    fn clone(&self) -> Self {
+        Self {
+            message: self.message.clone(),
+            state: self.state.clone(),
+        }
+    }
+}
+
 /// Optional parameters for client login finish
+#[derive(Clone)]
 pub enum ClientLoginFinishParameters {
     /// Specifying a user identifier and server identifier that will be matched against the client
     WithIdentifiers(Vec<u8>, Vec<u8>),
@@ -510,6 +586,21 @@ pub struct ClientLoginFinishResult<CS: CipherSuite> {
     /// Instance of the ClientLogin, only used in tests for checking zeroize
     #[cfg(test)]
     pub state: ClientLogin<CS>,
+}
+
+// Cannot be derived because it would require for CS to be Clone.
+impl<CS: CipherSuite> Clone for ClientLoginFinishResult<CS> {
+    fn clone(&self) -> Self {
+        Self {
+            message: self.message.clone(),
+            session_key: self.session_key.clone(),
+            export_key: self.export_key.clone(),
+            server_s_pk: self.server_s_pk.clone(),
+            confidential_info: self.confidential_info.clone(),
+            #[cfg(test)]
+            state: self.state.clone(),
+        }
+    }
 }
 
 impl<CS: CipherSuite> ClientLogin<CS> {
@@ -660,7 +751,18 @@ pub struct ServerLogin<CS: CipherSuite> {
     _cs: PhantomData<CS>,
 }
 
+// Cannot be derived because it would require for CS to be Clone.
+impl<CS: CipherSuite> Clone for ServerLogin<CS> {
+    fn clone(&self) -> Self {
+        Self {
+            ke2_state: self.ke2_state.clone(),
+            _cs: PhantomData,
+        }
+    }
+}
+
 /// Optional parameters for server login start
+#[derive(Clone)]
 pub enum ServerLoginStartParameters {
     /// Specifying a confidential info field that will be sent to the client
     WithInfo(Vec<u8>),
@@ -688,6 +790,17 @@ pub struct ServerLoginStartResult<CS: CipherSuite> {
     pub plain_info: Vec<u8>,
 }
 
+// Cannot be derived because it would require for CS to be Clone.
+impl<CS: CipherSuite> Clone for ServerLoginStartResult<CS> {
+    fn clone(&self) -> Self {
+        Self {
+            message: self.message.clone(),
+            state: self.state.clone(),
+            plain_info: self.plain_info.clone(),
+        }
+    }
+}
+
 /// Contains the fields that are returned by a server login finish
 pub struct ServerLoginFinishResult<CS: CipherSuite> {
     /// The session key between client and server
@@ -696,6 +809,18 @@ pub struct ServerLoginFinishResult<CS: CipherSuite> {
     /// Instance of the ClientRegistration, only used in tests for checking zeroize
     #[cfg(test)]
     pub state: ServerLogin<CS>,
+}
+
+// Cannot be derived because it would require for CS to be Clone.
+impl<CS: CipherSuite> Clone for ServerLoginFinishResult<CS> {
+    fn clone(&self) -> Self {
+        Self {
+            session_key: self.session_key.clone(),
+            _cs: PhantomData,
+            #[cfg(test)]
+            state: self.state.clone(),
+        }
+    }
 }
 
 impl<CS: CipherSuite> ServerLogin<CS> {

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -12,6 +12,7 @@ use generic_array::GenericArray;
 use rand::{CryptoRng, RngCore};
 
 /// Used to store the OPRF input and blinding factor
+#[derive(Clone)]
 pub struct Token<Grp: Group> {
     pub(crate) data: Vec<u8>,
     pub(crate) blind: Grp::Scalar,


### PR DESCRIPTION
This makes it much easier to handle the messages as part of a framework (e.g. actix where in some cases move-only is not possible). Note that it was _technically_ possible so far using `serialize` and `deserialize`, but that's inefficient and ugly.

Note that just using `#[derive(Clone)]` is not possible for many of the types, since they are generic over `CS`, and deriving `Clone` would add the requirement that `CS` is `Clone`, which in turns would require `KeyExchange` to be `Clone`, which doesn't make sense (we never own an instance of it).