### PR TITLE
Enforce public vs private keys via types

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -6,7 +6,7 @@
 use crate::{
     errors::{utils::check_slice_size_atleast, InternalPakeError, PakeError, ProtocolError},
     hash::Hash,
-    keypair::Key,
+    keypair::PublicKey,
     serialization::serialize,
 };
 use digest::Digest;
@@ -64,7 +64,7 @@ impl InnerEnvelope {
         }
         let mode = InnerEnvelopeMode::try_from(input[0])?;
 
-        let key_len = <Key as SizedBytes>::Len::to_usize();
+        let key_len = <PublicKey as SizedBytes>::Len::to_usize();
 
         let bytes = &input[1..];
         if bytes.len() < NONCE_LEN + key_len {
@@ -248,7 +248,7 @@ impl<D: Hash> Envelope<D> {
         let aad = construct_aad(server_s_pk, optional_ids);
         let opened = self.open_raw(key, &aad)?;
 
-        if opened.plaintext.len() != <Key as SizedBytes>::Len::to_usize() {
+        if opened.plaintext.len() != <PublicKey as SizedBytes>::Len::to_usize() {
             // Plaintext should consist of a single key
             return Err(InternalPakeError::UnexpectedEnvelopeContentsError);
         }

--- a/src/key_exchange/traits.rs
+++ b/src/key_exchange/traits.rs
@@ -8,7 +8,7 @@ use crate::{
     errors::{PakeError, ProtocolError},
     group::Group,
     hash::Hash,
-    keypair::Key,
+    keypair::{PrivateKey, PublicKey},
 };
 use rand::{CryptoRng, RngCore};
 use zeroize::Zeroize;
@@ -31,8 +31,8 @@ pub trait KeyExchange<D: Hash, G: Group> {
         l1_bytes: Vec<u8>,
         l2_bytes: Vec<u8>,
         ke1_message: Self::KE1Message,
-        client_s_pk: Key,
-        server_s_sk: Key,
+        client_s_pk: PublicKey,
+        server_s_sk: PrivateKey,
         id_u: Vec<u8>,
         id_s: Vec<u8>,
         e_info: Vec<u8>,
@@ -44,8 +44,8 @@ pub trait KeyExchange<D: Hash, G: Group> {
         ke2_message: Self::KE2Message,
         ke1_state: &Self::KE1State,
         serialized_credential_request: &[u8],
-        server_s_pk: Key,
-        client_s_sk: Key,
+        server_s_pk: PublicKey,
+        client_s_sk: PrivateKey,
         id_u: Vec<u8>,
         id_s: Vec<u8>,
     ) -> Result<(Vec<u8>, Vec<u8>, Self::KE3Message), ProtocolError>;

--- a/src/tests/full_test.rs
+++ b/src/tests/full_test.rs
@@ -10,7 +10,7 @@ use crate::{
     errors::*,
     group::Group,
     key_exchange::tripledh::{NonceLen, TripleDH},
-    keypair::{Key, SizedBytesExt},
+    keypair::{PrivateKey, PublicKey, SizedBytesExt},
     opaque::*,
     slow_hash::NoOpHash,
     tests::mock_rng::CycleRng,
@@ -494,7 +494,7 @@ fn test_registration_response() -> Result<(), ProtocolError> {
         ServerRegistration::<RistrettoSha5123dhNoSlowHash>::start(
             &mut oprf_key_rng,
             RegistrationRequest::deserialize(&parameters.registration_request[..])?,
-            &Key::from_bytes(&parameters.server_s_pk[..])?,
+            &PublicKey::from_bytes(&parameters.server_s_pk[..])?,
         )?;
     assert_eq!(
         hex::encode(parameters.registration_response),
@@ -589,7 +589,7 @@ fn test_credential_response() -> Result<(), ProtocolError> {
     let server_login_start_result = ServerLogin::<RistrettoSha5123dhNoSlowHash>::start(
         &mut server_e_sk_and_nonce_rng,
         ServerRegistration::deserialize(&parameters.password_file[..])?,
-        &Key::from_bytes(&parameters.server_s_sk[..])?,
+        &PrivateKey::from_bytes(&parameters.server_s_sk[..])?,
         CredentialRequest::<RistrettoSha5123dhNoSlowHash>::deserialize(
             &parameters.credential_request[..],
         )?,

--- a/src/tests/opaque_test_vectors.rs
+++ b/src/tests/opaque_test_vectors.rs
@@ -7,7 +7,7 @@ use crate::{
     ciphersuite::CipherSuite,
     errors::*,
     key_exchange::tripledh::TripleDH,
-    keypair::{Key, SizedBytesExt},
+    keypair::{PrivateKey, PublicKey, SizedBytesExt},
     opaque::*,
     slow_hash::NoOpHash,
     tests::mock_rng::CycleRng,
@@ -356,7 +356,7 @@ fn get_password_file_bytes(parameters: &TestVectorParameters) -> Result<Vec<u8>,
         ServerRegistration::<Ristretto255Sha512NoSlowHash>::start(
             &mut oprf_key_rng,
             RegistrationRequest::deserialize(&parameters.registration_request[..]).unwrap(),
-            &Key::from_bytes(&parameters.server_public_key[..]).unwrap(),
+            &PublicKey::from_bytes(&parameters.server_public_key[..]).unwrap(),
         )?;
 
     let password_file = server_registration_start_result
@@ -391,7 +391,7 @@ fn test_registration_response() -> Result<(), ProtocolError> {
             ServerRegistration::<Ristretto255Sha512NoSlowHash>::start(
                 &mut oprf_key_rng,
                 RegistrationRequest::deserialize(&parameters.registration_request[..]).unwrap(),
-                &Key::from_bytes(&parameters.server_public_key[..]).unwrap(),
+                &PublicKey::from_bytes(&parameters.server_public_key[..]).unwrap(),
             )?;
         assert_eq!(
             hex::encode(parameters.registration_response),
@@ -473,7 +473,7 @@ fn test_ke2() -> Result<(), ProtocolError> {
         let server_login_start_result = ServerLogin::<Ristretto255Sha512NoSlowHash>::start(
             &mut server_private_keyshare_and_nonce_rng,
             ServerRegistration::deserialize(&password_file_bytes[..]).unwrap(),
-            &Key::from_bytes(&parameters.server_private_key[..]).unwrap(),
+            &PrivateKey::from_bytes(&parameters.server_private_key[..]).unwrap(),
             CredentialRequest::<Ristretto255Sha512NoSlowHash>::deserialize(&parameters.KE1[..])
                 .unwrap(),
             if parameters.envelope_mode == EnvelopeMode::CustomIdentifier {
@@ -556,7 +556,7 @@ fn test_server_login_finish() -> Result<(), ProtocolError> {
         let server_login_start_result = ServerLogin::<Ristretto255Sha512NoSlowHash>::start(
             &mut server_private_keyshare_and_nonce_rng,
             ServerRegistration::deserialize(&password_file_bytes[..]).unwrap(),
-            &Key::from_bytes(&parameters.server_private_key[..]).unwrap(),
+            &PrivateKey::from_bytes(&parameters.server_private_key[..]).unwrap(),
             CredentialRequest::<Ristretto255Sha512NoSlowHash>::deserialize(&parameters.KE1[..])
                 .unwrap(),
             if parameters.envelope_mode == EnvelopeMode::CustomIdentifier {


### PR DESCRIPTION
With this change, it's no longer possible to pass a public key where a private one is expected, and vice-versa.

I *might* have made the mistake when using this library :) 