### PR TITLE
Implement common traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ slow-hash = ["argon2"]
 bench = []
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
-serialize = ["serde", "base64"]
+serialize = ["serde", "base64", "generic-array/serde", "curve25519-dalek/serde"]
 
 [dependencies]
 argon2 = { version = "0.2", optional = true }
@@ -28,7 +28,7 @@ generic-bytes = { version = "0.1.0" }
 hkdf = "0.11.0"
 hmac = "0.11.0"
 rand = "0.8"
-serde = { version = "1", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
 subtle = { version = "2.3.0", default-features = false }
 thiserror = "1.0.22"
 zeroize = { version = "1.1.1", features = ["zeroize_derive"] }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -61,7 +61,7 @@ fn recover_keys_internal<CS: CipherSuite>(
     Ok(client_static_keypair)
 }
 
-#[derive(Clone, Copy, PartialEq, Zeroize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Zeroize)]
 #[zeroize(drop)]
 pub(crate) enum InnerEnvelopeMode {
     Zero = 0,
@@ -104,6 +104,8 @@ impl<CS: CipherSuite> Clone for Envelope<CS> {
         }
     }
 }
+
+impl_debug_eq_hash_for!(struct Envelope<CS: CipherSuite>, [mode, nonce, hmac]);
 
 // Note that this struct represents an envelope that has been "opened" with the asssociated
 // key. This key is also used to derive the export_key parameter, which is technically

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,0 +1,97 @@
+macro_rules! impl_debug_eq_hash_for {
+    (struct $name:ident$(<$($gen:ident$(: $bound:tt)?),+$(,)?>)?, [$field1:ident$(, $field2:ident)*$(,)?]$(, )?$([$($type:ty),+$(,)?]$(,)?)?) => {
+        impl$(<$($gen$(: $bound)?),+>)? std::fmt::Debug for $name$(<$($gen),+>)?
+        $(where $($type: std::fmt::Debug,)+)?
+        {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_struct("$name")
+                .field("$field1", &self.$field1)
+                $(.field("$field2", &self.$field2))*
+                .finish()
+            }
+        }
+
+        impl$(<$($gen$(: $bound)?),+>)? Eq for $name$(<$($gen),+>)?
+        $(where $($type: Eq,)+)?
+        {}
+
+        impl$(<$($gen$(: $bound)?),+>)? PartialEq for $name$(<$($gen),+>)?
+        $(where $($type: PartialEq,)+)?
+        {
+            fn eq(&self, other: &Self) -> bool {
+                PartialEq::eq(&self.$field1, &other.$field1)
+                $(&& PartialEq::eq(&self.$field2, &other.$field2))*
+            }
+        }
+
+        impl$(<$($gen$(: $bound)?),+>)? std::hash::Hash for $name$(<$($gen),+>)?
+        $(where $($type: std::hash::Hash,)+)?
+        {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                std::hash::Hash::hash(&self.$field1, state);
+                $(std::hash::Hash::hash(&self.$field2, state);)*
+            }
+        }
+    };
+    (tuple $name:ident$(<$($gen:ident$(: $bound:tt)?),+$(,)?>)?, [$field1:tt$(, $field2:tt)*$(,)?]$(, )?$([$($type:ty),+$(,)?]$(,)?)?) => {
+        impl$(<$($gen$(: $bound)?),+>)? std::fmt::Debug for $name$(<$($gen),+>)?
+        $(where $($type: std::fmt::Debug,)+)?
+        {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_tuple("$name")
+                .field(&self.$field1)
+                $(.field(&self.$field2))*
+                .finish()
+            }
+        }
+
+        impl$(<$($gen$(: $bound)?),+>)? Eq for $name$(<$($gen),+>)?
+        $(where $($type: Eq,)+)?
+        {}
+
+        impl$(<$($gen$(: $bound)?),+>)? PartialEq for $name$(<$($gen),+>)?
+        $(where $($type: PartialEq,)+)?
+        {
+            fn eq(&self, other: &Self) -> bool {
+                PartialEq::eq(&self.$field1, &other.$field1)
+                $(&& PartialEq::eq(&self.$field2, &other.$field2))*
+            }
+        }
+
+        impl$(<$($gen$(: $bound)?),+>)? std::hash::Hash for $name$(<$($gen),+>)?
+        $(where $($type: std::hash::Hash,)+)?
+        {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                std::hash::Hash::hash(&self.$field1, state);
+                $(std::hash::Hash::hash(&self.$field2, state);)*
+            }
+        }
+    };
+}
+
+macro_rules! impl_clone_for {
+    (struct $name:ident$(<$($gen:ident$(: $bound:tt)?),+$(,)?>)?, [$field1:ident$(, $field2:ident)*$(,)?]$(, )?$([$($type:ty),+$(,)?]$(,)?)?) => {
+        impl$(<$($gen$(: $bound)?),+>)? Clone for $name$(<$($gen),+>)?
+        $(where $($type: Clone,)+)?
+        {
+            fn clone(&self) -> Self {
+                Self {
+                    $field1: self.$field1.clone(),
+                    $($field2: self.$field2.clone(),)*
+                }
+            }
+        }
+    };
+    (tuple $name:ident$(<$($gen:ident$(: $bound:tt)?),+$(,)?>)?, [$field1:tt$(, $field2:tt)*$(,)?]$(, )?$([$($type:ty),+$(,)?]$(,)?)?) => {
+        impl$(<$($gen$(: $bound)?),+>)? Clone for $name$(<$($gen),+>)?
+        $(where $($type: Clone,)+)?
+        {
+            fn clone(&self) -> Self {
+                Self(
+                    self.$field1.clone(),
+                    $(self.$field2.clone(),)*
+                )
+            }
+        }
+    };
+}

--- a/src/key_exchange/tripledh.rs
+++ b/src/key_exchange/tripledh.rs
@@ -207,7 +207,8 @@ impl<D: Hash, G: Group> KeyExchange<D, G> for TripleDH {
 }
 
 /// The client state produced after the first key exchange message
-#[derive(PartialEq, Eq, Zeroize, Clone)]
+#[derive(PartialEq, Eq, Debug, Hash, Zeroize, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 #[zeroize(drop)]
 pub struct Ke1State {
     client_e_sk: PrivateKey,
@@ -215,7 +216,8 @@ pub struct Ke1State {
 }
 
 /// The first key exchange message
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 pub struct Ke1Message {
     pub(crate) client_nonce: GenericArray<u8, NonceLen>,
     pub(crate) client_e_pk: PublicKey,
@@ -272,7 +274,9 @@ impl FromBytes for Ke1Message {
     }
 }
 /// The server state produced after the second key exchange message
-#[derive(Clone)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serialize", serde(bound = ""))]
 pub struct Ke2State<HashLen: ArrayLength<u8>> {
     km3: GenericArray<u8, HashLen>,
     hashed_transcript: GenericArray<u8, HashLen>,
@@ -315,7 +319,9 @@ impl<HashLen: ArrayLength<u8>> ToBytesWithPointers for Ke2State<HashLen> {
 }
 
 /// The second key exchange message
-#[derive(Clone)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serialize", serde(bound = ""))]
 pub struct Ke2Message<HashLen: ArrayLength<u8>> {
     server_nonce: GenericArray<u8, NonceLen>,
     server_e_pk: PublicKey,
@@ -398,7 +404,9 @@ type TripleDHDerivationResult<D> = (
 );
 
 /// The third key exchange message
-#[derive(Clone)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serialize", serde(bound = ""))]
 pub struct Ke3Message<HashLen: ArrayLength<u8>> {
     mac: GenericArray<u8, HashLen>,
 }

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -35,12 +35,21 @@ pub trait SizedBytesExt: SizedBytes {
 impl<T> SizedBytesExt for T where T: SizedBytes {}
 
 /// A Keypair trait with public-private verification
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 pub struct KeyPair<G> {
     pk: PublicKey,
     sk: PrivateKey,
     _g: PhantomData<G>,
 }
+
+impl_clone_for!(
+    struct KeyPair<G>,
+    [pk, sk, _g],
+);
+impl_debug_eq_hash_for!(
+    struct KeyPair<G>,
+    [pk, sk, _g],
+);
 
 // This can't be derived because of the use of a phantom parameter
 impl<G> Zeroize for KeyPair<G> {
@@ -154,7 +163,8 @@ impl<G: Group + Debug> KeyPair<G> {
 type KeyLen = U32;
 
 /// A minimalist key type built around a \[u8; 32\]
-#[derive(Debug, PartialEq, Eq, Clone, Zeroize)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Zeroize)]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 // Ensure Key material is zeroed after use.
 #[zeroize(drop)]
 #[repr(transparent)]
@@ -181,7 +191,8 @@ impl Key {
 }
 
 /// Wrapper around a Key to enforce that it's a private one.
-#[derive(Debug, PartialEq, Eq, Clone, Zeroize)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Zeroize)]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 // Ensure Key material is zeroed after use.
 #[zeroize(drop)]
 #[repr(transparent)]
@@ -208,7 +219,8 @@ impl SizedBytes for PrivateKey {
 }
 
 /// Wrapper around a Key to enforce that it's a public one.
-#[derive(Debug, PartialEq, Eq, Clone, Zeroize)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Zeroize)]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 // Ensure Key material is zeroed after use.
 #[zeroize(drop)]
 #[repr(transparent)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -748,6 +748,8 @@ compile_error!(
 pub mod errors;
 
 #[macro_use]
+mod impls;
+#[macro_use]
 mod serialization;
 
 // High-level API

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -46,6 +46,8 @@ impl<CS: CipherSuite> Clone for RegistrationRequest<CS> {
     }
 }
 
+impl_debug_eq_hash_for!(struct RegistrationRequest<CS: CipherSuite>, [alpha], [CS::Group]);
+
 impl<CS: CipherSuite> RegistrationRequest<CS> {
     /// Serialization into bytes
     pub fn serialize(&self) -> Vec<u8> {
@@ -89,6 +91,12 @@ impl<CS: CipherSuite> Clone for RegistrationResponse<CS> {
         }
     }
 }
+
+impl_debug_eq_hash_for!(
+    struct RegistrationResponse<CS: CipherSuite>,
+    [beta, server_s_pk],
+    [CS::Group],
+);
 
 impl<CS: CipherSuite> RegistrationResponse<CS> {
     /// Serialization into bytes
@@ -136,16 +144,14 @@ pub struct RegistrationUpload<CS: CipherSuite> {
     pub(crate) client_s_pk: PublicKey,
 }
 
-// Cannot be derived because it would require for CS to be Clone.
-impl<CS: CipherSuite> Clone for RegistrationUpload<CS> {
-    fn clone(&self) -> Self {
-        Self {
-            envelope: self.envelope.clone(),
-            masking_key: self.masking_key.clone(),
-            client_s_pk: self.client_s_pk.clone(),
-        }
-    }
-}
+impl_clone_for!(
+    struct RegistrationUpload<CS: CipherSuite>,
+    [envelope, masking_key, client_s_pk],
+);
+impl_debug_eq_hash_for!(
+    struct RegistrationUpload<CS: CipherSuite>,
+    [envelope, masking_key, client_s_pk],
+);
 
 impl<CS: CipherSuite> RegistrationUpload<CS> {
     /// Serialization into bytes
@@ -211,6 +217,15 @@ impl<CS: CipherSuite> Clone for CredentialRequest<CS> {
     }
 }
 
+impl_debug_eq_hash_for!(
+    struct CredentialRequest<CS: CipherSuite>,
+    [alpha, ke1_message],
+    [
+        CS::Group,
+        <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE1Message
+    ],
+);
+
 impl<CS: CipherSuite> CredentialRequest<CS> {
     /// Serialization into bytes
     pub fn serialize(&self) -> Vec<u8> {
@@ -265,6 +280,15 @@ impl<CS: CipherSuite> Clone for CredentialResponse<CS> {
         }
     }
 }
+
+impl_debug_eq_hash_for!(
+    struct CredentialResponse<CS: CipherSuite>,
+    [beta, masking_nonce, masked_response, ke2_message],
+    [
+        CS::Group,
+        <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE2Message,
+    ],
+);
 
 impl<CS: CipherSuite> CredentialResponse<CS> {
     /// Serialization into bytes
@@ -336,14 +360,12 @@ pub struct CredentialFinalization<CS: CipherSuite> {
     pub(crate) ke3_message: <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE3Message,
 }
 
-// Cannot be derived because it would require for CS to be Clone.
-impl<CS: CipherSuite> Clone for CredentialFinalization<CS> {
-    fn clone(&self) -> Self {
-        Self {
-            ke3_message: self.ke3_message.clone(),
-        }
-    }
-}
+impl_clone_for!(struct CredentialFinalization<CS: CipherSuite>, [ke3_message]);
+impl_debug_eq_hash_for!(
+    struct CredentialFinalization<CS: CipherSuite>,
+    [ke3_message],
+    [<CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE3Message],
+);
 
 impl<CS: CipherSuite> CredentialFinalization<CS> {
     /// Serialization into bytes

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -12,11 +12,13 @@ use generic_array::GenericArray;
 use rand::{CryptoRng, RngCore};
 
 /// Used to store the OPRF input and blinding factor
-#[derive(Clone)]
 pub struct Token<Grp: Group> {
     pub(crate) data: Vec<u8>,
     pub(crate) blind: Grp::Scalar,
 }
+
+impl_clone_for!(struct Token<Grp: Group>, [data, blind]);
+impl_debug_eq_hash_for!(struct Token<Grp: Group>, [data, blind], [Grp::Scalar]);
 
 static STR_VOPRF: &[u8] = b"VOPRF06-HashToGroup-";
 static STR_VOPRF_FINALIZE: &[u8] = b"VOPRF06-Finalize-";


### PR DESCRIPTION
This is an attempt to make sure that all exposed types implement `Clone`, `Debug`, `Deserialize` and `Serialize`. As a bonus I threw in `Eq`, `Hash` and `PartialEq` because it was no extra effort.

I skipped on implementing it on the `XxxResult` types because their public members are covered, which works great for our use-case, but adding them would be simple.

`Hash` might not be appropriate in a couple of places, I wouldn't know.