### PR TITLE
Increase MSRV to 1.51

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           - u32_backend
         toolchain:
           - stable
-          - 1.41.0
+          - 1.51.0
     name: test
     steps:
       - name: Checkout sources
@@ -94,7 +94,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.41.0
+          - 1.51.0
     name: test simple_login command-line example
     steps:
       - name: install expect
@@ -118,7 +118,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.41.0
+          - 1.51.0
     name: test digital_locker command-line example
     steps:
       - name: install expect

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,32 +20,32 @@ serialize = ["serde", "base64", "generic-array/serde", "curve25519-dalek/serde"]
 [dependencies]
 argon2 = { version = "0.2", optional = true }
 base64 = { version = "0.13", optional = true }
-constant_time_eq = "0.1.5"
-curve25519-dalek = { version = "3.1.0", default-features = false, features = ["std"] }
-digest = "0.9.0"
-displaydoc = "0.1.7"
-generic-array = "0.14.4"
-generic-bytes = { version = "0.1.0" }
-hkdf = "0.11.0"
-hmac = "0.11.0"
+constant_time_eq = "0.1"
+curve25519-dalek = { version = "3", default-features = false, features = ["std"] }
+digest = "0.9"
+displaydoc = "0.2"
+generic-array = "0.14"
+generic-bytes = { version = "0.1" }
+hkdf = "0.11"
+hmac = "0.11"
 rand = "0.8"
 serde = { version = "1", features = ["derive"], optional = true }
-subtle = { version = "2.3.0", default-features = false }
-thiserror = "1.0.22"
-zeroize = { version = "~1.1.1", features = ["zeroize_derive"] }
+subtle = { version = "2.3", default-features = false }
+thiserror = "1"
+zeroize = { version = "1", features = ["zeroize_derive"] }
 
 [dev-dependencies]
-anyhow = "1.0.35"
-base64 = "0.13.0"
+anyhow = "1"
+base64 = "0.13"
 bincode = "1"
-chacha20poly1305 = "0.7.1"
-criterion = "=0.3.4"
-hex = "0.4.2"
-lazy_static = "1.4.0"
-serde_json = "1.0.60"
-sha2 = "0.9.2"
-proptest = "0.10.1"
-rustyline = "6.3.0"
+chacha20poly1305 = "0.8"
+criterion = "0.3"
+hex = "0.4"
+lazy_static = "1"
+serde_json = "1"
+sha2 = "0.9"
+proptest = "1"
+rustyline = "8"
 
 [[bench]]
 name = "oprf"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Add the following line to the dependencies of your `Cargo.toml`:
 opaque-ke = "0.6.0"
 ```
 
+### Minimum Supported Rust Version
+
+Rust **1.51** or higher.
+
 Resources
 ---------
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -40,23 +40,23 @@ pub enum InternalPakeError<T = Infallible> {
     HmacError,
     /// Computing the slow hashing function failed
     SlowHashError,
-    /// This error occurs when the envelope seal fails
-    /// Constructing the envelope seal failed.
+    /** This error occurs when the envelope seal fails
+    Constructing the envelope seal failed. */
     SealError,
-    /// This error occurs when the envelope seal open fails
-    /// Opening the envelope seal failed.
+    /** This error occurs when the envelope seal open fails
+    Opening the envelope seal failed. */
     SealOpenError,
-    /// This error occurs when the envelope seal open hmac check fails
-    /// HMAC check in seal open failed.
+    /** This error occurs when the envelope seal open hmac check fails
+    HMAC check in seal open failed. */
     SealOpenHmacError,
-    /// This error occurs when the envelope cannot be constructed properly
-    /// based on the credentials that were specified to be required.
+    /** This error occurs when the envelope cannot be constructed properly
+    based on the credentials that were specified to be required. */
     InvalidEnvelopeStructureError,
-    /// This error occurs when attempting to open an envelope of the wrong
-    /// type (base mode, custom identifier)
+    /** This error occurs when attempting to open an envelope of the wrong
+    type (base mode, custom identifier) */
     IncompatibleEnvelopeModeError,
-    /// This error occurs when the envelope is opened and deserialization
-    /// fails
+    /** This error occurs when the envelope is opened and deserialization
+    fails */
     UnexpectedEnvelopeContentsError,
 }
 
@@ -137,12 +137,12 @@ impl InternalPakeError {
 /// Represents an error in password checking
 #[derive(Clone, Display, Eq, Hash, PartialEq)]
 pub enum PakeError<T = Infallible> {
-    /// This error results from an internal error during PRF construction
-    ///
-    /// Internal error during PRF verification: {0}
+    /** This error results from an internal error during PRF construction
+
+    Internal error during PRF verification: {0} */
     CryptoError(InternalPakeError<T>),
-    /// This error occurs when the server object that is being called finish() on is malformed
-    /// Incomplete set of keys passed into finish() function
+    /** This error occurs when the server object that is being called finish() on is malformed
+    Incomplete set of keys passed into finish() function */
     IncompleteKeysError,
     /// The provided server public key doesn't match the sealed one
     IncompatibleServerStaticPublicKeyError,
@@ -209,23 +209,23 @@ impl PakeError {
 /// Represents an error in protocol handling
 #[derive(Clone, Display, Eq, Hash, PartialEq)]
 pub enum ProtocolError<T = Infallible> {
-    /// This error results from an error during password verification
-    ///
-    /// Internal error during password verification: {0}
+    /** This error results from an error during password verification
+
+    Internal error during password verification: {0} */
     VerificationError(PakeError<T>),
     /// This error occurs when the inner envelope is malformed
     InvalidInnerEnvelopeError,
-    /// This error occurs when the server answer cannot be handled
-    /// Server response cannot be handled.
+    /** This error occurs when the server answer cannot be handled
+    Server response cannot be handled. */
     ServerError,
-    /// This error occurs when the server specifies an envelope credentials
-    /// format that is invalid
+    /** This error occurs when the server specifies an envelope credentials
+    format that is invalid */
     ServerInvalidEnvelopeCredentialsFormatError,
-    /// This error occurs when the client request cannot be handled
-    /// Client request cannot be handled.
+    /** This error occurs when the client request cannot be handled
+    Client request cannot be handled. */
     ClientError,
-    /// This error occurs when the client detects that the server has
-    /// reflected the OPRF value (beta == alpha)
+    /** This error occurs when the client detects that the server has
+    reflected the OPRF value (beta == alpha) */
     ReflectedValueError,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,10 @@
 //! Note: This implementation is in sync with [draft-irtf-cfrg-opaque-05](https://www.ietf.org/archive/id/draft-irtf-cfrg-opaque-05.html),
 //! but this specification is subject to change, until the final version published by the IETF.
 //!
+//! ### Minimum Supported Rust Version
+//!
+//! Rust **1.51** or higher.
+//!
 //! # Overview
 //!
 //! OPAQUE is a protocol between a client and a server. They must first agree on a collection of primitives


### PR DESCRIPTION
We discussed 1.53 actually, but it seems no dependency needs it, I also noticed that we don't document MSRV anywhere. Do you want me to add documentation? Is 1.51 alright or should I bump it to the newest right now, which is 1.54 actually?