### PR TITLE
Seperate AKE from OPRF

### DIFF
--- a/examples/digital_locker.rs
+++ b/examples/digital_locker.rs
@@ -44,6 +44,7 @@ use opaque_ke::{
 #[allow(dead_code)]
 struct Default;
 impl CipherSuite for Default {
+    type Ake = curve25519_dalek::ristretto::RistrettoPoint;
     type Group = curve25519_dalek::ristretto::RistrettoPoint;
     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
     type Hash = sha2::Sha512;

--- a/examples/simple_login.rs
+++ b/examples/simple_login.rs
@@ -37,6 +37,7 @@ use opaque_ke::{
 #[allow(dead_code)]
 struct Default;
 impl CipherSuite for Default {
+    type Ake = curve25519_dalek::ristretto::RistrettoPoint;
     type Group = curve25519_dalek::ristretto::RistrettoPoint;
     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
     type Hash = sha2::Sha512;

--- a/src/ake.rs
+++ b/src/ake.rs
@@ -1,0 +1,127 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+//! A algorithm for the authenticated key exchange used in `KeyExchange`
+
+use crate::errors::InternalPakeError;
+use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
+use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
+use curve25519_dalek::scalar::Scalar;
+use generic_array::typenum::U32;
+use generic_array::{ArrayLength, GenericArray};
+use rand::{CryptoRng, RngCore};
+
+/// A algorithm for the authenticated key exchange used in `KeyExchange`
+pub trait Ake: Sized {
+    /// Length of the public key
+    type PkLen: ArrayLength<u8> + 'static;
+    /// Length of the secret key
+    type SkLen: ArrayLength<u8> + 'static;
+
+    /// Return a public key from its fixed-length bytes representation
+    fn from_pk_slice(
+        element_bits: &GenericArray<u8, Self::PkLen>,
+    ) -> Result<Self, InternalPakeError>;
+
+    /// Generate a random secret key
+    fn random_sk<R: RngCore + CryptoRng>(rng: &mut R) -> GenericArray<u8, Self::SkLen>;
+
+    /// Return a public key from its secret key
+    fn public_key(sk: &GenericArray<u8, Self::SkLen>) -> Self;
+
+    /// Serializes `self`
+    fn to_arr(&self) -> GenericArray<u8, Self::PkLen>;
+
+    /// Diffie-Hellman key exchange
+    fn diffie_hellman(&self, sk: &GenericArray<u8, Self::SkLen>) -> GenericArray<u8, Self::PkLen>;
+}
+
+impl Ake for RistrettoPoint {
+    type PkLen = U32;
+
+    type SkLen = U32;
+
+    fn from_pk_slice(
+        element_bits: &GenericArray<u8, Self::PkLen>,
+    ) -> Result<Self, InternalPakeError> {
+        CompressedRistretto::from_slice(element_bits)
+            .decompress()
+            .ok_or(InternalPakeError::PointError)
+    }
+
+    fn random_sk<R: RngCore + CryptoRng>(rng: &mut R) -> GenericArray<u8, Self::SkLen> {
+        loop {
+            let scalar = {
+                #[cfg(not(test))]
+                {
+                    let mut scalar_bytes = [0u8; 64];
+                    rng.fill_bytes(&mut scalar_bytes);
+                    Scalar::from_bytes_mod_order_wide(&scalar_bytes)
+                }
+
+                // Tests need an exact conversion from bytes to scalar, sampling only 32 bytes from rng
+                #[cfg(test)]
+                {
+                    let mut scalar_bytes = [0u8; 32];
+                    rng.fill_bytes(&mut scalar_bytes);
+                    Scalar::from_bytes_mod_order(scalar_bytes)
+                }
+            };
+
+            if scalar != Scalar::zero() {
+                break scalar.to_bytes().into();
+            }
+        }
+    }
+
+    fn public_key(sk: &GenericArray<u8, Self::SkLen>) -> Self {
+        RISTRETTO_BASEPOINT_POINT * Scalar::from_bits(*sk.as_ref())
+    }
+
+    fn to_arr(&self) -> GenericArray<u8, Self::PkLen> {
+        self.compress().to_bytes().into()
+    }
+
+    fn diffie_hellman(&self, sk: &GenericArray<u8, Self::SkLen>) -> GenericArray<u8, Self::PkLen> {
+        (self * Scalar::from_bits(*sk.as_ref())).to_arr()
+    }
+}
+
+#[cfg(feature = "p256")]
+impl Ake for p256_::ProjectivePoint {
+    type PkLen = generic_array::typenum::U33;
+
+    type SkLen = U32;
+
+    fn from_pk_slice(
+        element_bits: &GenericArray<u8, Self::PkLen>,
+    ) -> Result<Self, InternalPakeError> {
+        use p256_::elliptic_curve::group::GroupEncoding;
+
+        Option::from(Self::from_bytes(element_bits)).ok_or(InternalPakeError::PointError)
+    }
+
+    fn random_sk<R: RngCore + CryptoRng>(rng: &mut R) -> GenericArray<u8, Self::SkLen> {
+        use p256_::elliptic_curve::Field;
+
+        p256_::Scalar::random(rng).into()
+    }
+
+    fn public_key(sk: &GenericArray<u8, Self::SkLen>) -> Self {
+        Self::generator() * p256_::Scalar::from_bytes_reduced(sk)
+    }
+
+    fn to_arr(&self) -> GenericArray<u8, Self::PkLen> {
+        use p256_::elliptic_curve::sec1::ToEncodedPoint;
+
+        let mut bytes = self.to_affine().to_encoded_point(true).as_bytes().to_vec();
+        bytes.resize(33, 0);
+        *GenericArray::from_slice(&bytes)
+    }
+
+    fn diffie_hellman(&self, sk: &GenericArray<u8, Self::SkLen>) -> GenericArray<u8, Self::PkLen> {
+        (self * &p256_::Scalar::from_bytes_reduced(sk)).to_arr()
+    }
+}

--- a/src/ciphersuite.rs
+++ b/src/ciphersuite.rs
@@ -5,22 +5,25 @@
 
 //! Defines the CipherSuite trait to specify the underlying primitives for OPAQUE
 
-use crate::{group::Group, hash::Hash, key_exchange::traits::KeyExchange, slow_hash::SlowHash};
+use crate::{
+    ake::Ake, group::Group, hash::Hash, key_exchange::traits::KeyExchange, slow_hash::SlowHash,
+};
 
 /// Configures the underlying primitives used in OPAQUE
-/// * `Group`: a finite cyclic group along with a point representation, along
-///   with an extension trait PasswordToCurve that allows some customization on
-///   how to hash a password to a curve point. See `group::Group`.
+/// * `Ake`: a algorithm for the authenticated key exchange used in `KeyExchange`
+/// * `Group`: a finite cyclic group along with a point representation, that can
+///    hash a password to a curve point used for OPRF. See `group::Group`.
 /// * `KeyExchange`: The key exchange protocol to use in the login step
 /// * `Hash`: The main hashing function to use
 /// * `SlowHash`: A slow hashing function, typically used for password hashing
 pub trait CipherSuite {
-    /// A finite cyclic group along with a point representation along with
-    /// an extension trait PasswordToCurve that allows some customization on
-    /// how to hash a password to a curve point. See `group::Group`.
+    /// A algorithm for the authenticated key exchange used in `KeyExchange`
+    type Ake: Ake;
+    /// A finite cyclic group along with a point representation, that can
+    /// hash a password to a curve point used for OPRF. See `group::Group`.
     type Group: Group;
     /// A key exchange protocol
-    type KeyExchange: KeyExchange<Self::Hash, Self::Group>;
+    type KeyExchange: KeyExchange<Self::Hash, Self::Ake>;
     /// The main hash function use (for HKDF computations and hashing transcripts)
     type Hash: Hash;
     /// A slow hashing function, typically used for password hashing

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -8,7 +8,7 @@ use crate::{
     errors::{utils::check_slice_size, InternalPakeError, PakeError, ProtocolError},
     group::Group,
     hash::Hash,
-    keypair::{KeyPair, PrivateKey, PublicKey},
+    keypair::{KeyPair, PublicKey},
     opaque::{bytestrings_from_identifiers, Identifiers},
 };
 use digest::Digest;
@@ -33,7 +33,7 @@ fn build_inner_envelope_internal<CS: CipherSuite>(
     nonce: &[u8],
 ) -> Result<PublicKey<CS::Ake>, ProtocolError> {
     let h = Hkdf::<CS::Hash>::new(None, random_pwd);
-    let mut keypair_seed = vec![0u8; <PrivateKey<CS::Ake> as SizedBytes>::Len::to_usize()];
+    let mut keypair_seed = vec![0u8; <CS::Ake as crate::ake::Ake>::SkLen::to_usize()];
     h.expand(&[nonce, STR_PRIVATE_KEY].concat(), &mut keypair_seed)
         .map_err(|_| InternalPakeError::HkdfError)?;
     let client_static_keypair =
@@ -49,7 +49,7 @@ fn recover_keys_internal<CS: CipherSuite>(
     nonce: &[u8],
 ) -> Result<KeyPair<CS::Ake>, ProtocolError> {
     let h = Hkdf::<CS::Hash>::new(None, random_pwd);
-    let mut keypair_seed = vec![0u8; <PrivateKey<CS::Ake> as SizedBytes>::Len::to_usize()];
+    let mut keypair_seed = vec![0u8; <CS::Ake as crate::ake::Ake>::SkLen::to_usize()];
     h.expand(&[nonce, STR_PRIVATE_KEY].concat(), &mut keypair_seed)
         .map_err(|_| InternalPakeError::HkdfError)?;
     let client_static_keypair =

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -63,12 +63,6 @@ pub trait Group: Copy + Sized + for<'a> Mul<&'a <Self as Group>::Scalar, Output 
     /// Serializes the `self` group element
     fn to_arr(&self) -> GenericArray<u8, Self::ElemLen>;
 
-    /// Get the base point for the group
-    fn base_point() -> Self;
-
-    /// Multiply the point by a scalar, represented as a slice
-    fn mult_by_slice(&self, scalar: &GenericArray<u8, Self::ScalarLen>) -> Self;
-
     /// Returns if the group element is equal to the identity (1)
     fn is_identity(&self) -> bool;
 

--- a/src/group/p256.rs
+++ b/src/group/p256.rs
@@ -142,14 +142,6 @@ impl Group for ProjectivePoint {
         *GenericArray::from_slice(&bytes)
     }
 
-    fn base_point() -> Self {
-        Self::generator()
-    }
-
-    fn mult_by_slice(&self, scalar: &GenericArray<u8, Self::ScalarLen>) -> Self {
-        self * &Self::Scalar::from_bytes_reduced(scalar)
-    }
-
     fn is_identity(&self) -> bool {
         self == &Self::identity()
     }

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -7,7 +7,6 @@ use super::Group;
 use crate::errors::{InternalPakeError, ProtocolError};
 use crate::hash::Hash;
 use curve25519_dalek::{
-    constants::RISTRETTO_BASEPOINT_POINT,
     ristretto::{CompressedRistretto, RistrettoPoint},
     scalar::Scalar,
     traits::Identity,
@@ -97,14 +96,6 @@ impl Group for RistrettoPoint {
     // serialization of a group element
     fn to_arr(&self) -> GenericArray<u8, Self::ElemLen> {
         self.compress().to_bytes().into()
-    }
-
-    fn base_point() -> Self {
-        RISTRETTO_BASEPOINT_POINT
-    }
-
-    fn mult_by_slice(&self, scalar: &GenericArray<u8, Self::ScalarLen>) -> Self {
-        self * Scalar::from_bits(*scalar.as_ref())
     }
 
     /// Returns if the group element is equal to the identity (1)

--- a/src/key_exchange/traits.rs
+++ b/src/key_exchange/traits.rs
@@ -4,9 +4,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{
+    ake::Ake,
     ciphersuite::CipherSuite,
     errors::{PakeError, ProtocolError},
-    group::Group,
     hash::Hash,
     keypair::{PrivateKey, PublicKey, SecretKey},
 };
@@ -35,7 +35,7 @@ pub type GenerateKe3Result<K, D, G> = (
     generic_array::GenericArray<u8, <D as digest::Digest>::OutputSize>,
 );
 
-pub trait KeyExchange<D: Hash, G: Group> {
+pub trait KeyExchange<D: Hash, A: Ake> {
     type KE1State: FromBytes + ToBytesWithPointers + Zeroize + Clone;
     type KE2State: FromBytes + ToBytesWithPointers + Zeroize + Clone;
     type KE1Message: FromBytes + ToBytes + Clone;
@@ -47,17 +47,17 @@ pub trait KeyExchange<D: Hash, G: Group> {
     ) -> Result<(Self::KE1State, Self::KE1Message), ProtocolError>;
 
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]
-    fn generate_ke2<R: RngCore + CryptoRng, S: SecretKey<G>>(
+    fn generate_ke2<R: RngCore + CryptoRng, S: SecretKey<A>>(
         rng: &mut R,
         l1_bytes: Vec<u8>,
         l2_bytes: Vec<u8>,
         ke1_message: Self::KE1Message,
-        client_s_pk: PublicKey<G>,
+        client_s_pk: PublicKey<A>,
         server_s_sk: S,
         id_u: Vec<u8>,
         id_s: Vec<u8>,
         context: Vec<u8>,
-    ) -> Result<GenerateKe2Result<Self, D, G>, ProtocolError<S::Error>>;
+    ) -> Result<GenerateKe2Result<Self, D, A>, ProtocolError<S::Error>>;
 
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     fn generate_ke3(
@@ -65,12 +65,12 @@ pub trait KeyExchange<D: Hash, G: Group> {
         ke2_message: Self::KE2Message,
         ke1_state: &Self::KE1State,
         serialized_credential_request: &[u8],
-        server_s_pk: PublicKey<G>,
-        client_s_sk: PrivateKey<G>,
+        server_s_pk: PublicKey<A>,
+        client_s_sk: PrivateKey<A>,
         id_u: Vec<u8>,
         id_s: Vec<u8>,
         context: Vec<u8>,
-    ) -> Result<GenerateKe3Result<Self, D, G>, ProtocolError>;
+    ) -> Result<GenerateKe3Result<Self, D, A>, ProtocolError>;
 
     #[allow(clippy::type_complexity)]
     fn finish_ke(

--- a/src/key_exchange/tripledh.rs
+++ b/src/key_exchange/tripledh.rs
@@ -5,12 +5,12 @@
 
 //! An implementation of the Triple Diffie-Hellman key exchange protocol
 use crate::{
+    ake::Ake,
     ciphersuite::CipherSuite,
     errors::{
         utils::{check_slice_size, check_slice_size_atleast},
         InternalPakeError, PakeError, ProtocolError,
     },
-    group::Group,
     hash::Hash,
     key_exchange::traits::{
         FromBytes, GenerateKe2Result, GenerateKe3Result, KeyExchange, ToBytes, ToBytesWithPointers,
@@ -43,17 +43,17 @@ static STR_OPAQUE: &[u8] = b"OPAQUE-";
 /// The Triple Diffie-Hellman key exchange implementation
 pub struct TripleDH;
 
-impl<D: Hash, G: Group> KeyExchange<D, G> for TripleDH {
-    type KE1State = Ke1State<G>;
+impl<D: Hash, A: Ake> KeyExchange<D, A> for TripleDH {
+    type KE1State = Ke1State<A>;
     type KE2State = Ke2State<<D as FixedOutput>::OutputSize>;
-    type KE1Message = Ke1Message<G>;
-    type KE2Message = Ke2Message<G, <D as FixedOutput>::OutputSize>;
+    type KE1Message = Ke1Message<A>;
+    type KE2Message = Ke2Message<A, <D as FixedOutput>::OutputSize>;
     type KE3Message = Ke3Message<<D as FixedOutput>::OutputSize>;
 
     fn generate_ke1<R: RngCore + CryptoRng>(
         rng: &mut R,
     ) -> Result<(Self::KE1State, Self::KE1Message), ProtocolError> {
-        let client_e_kp = KeyPair::<G>::generate_random(rng);
+        let client_e_kp = KeyPair::<A>::generate_random(rng);
         let client_nonce = generate_nonce::<R>(rng);
 
         let ke1_message = Ke1Message {
@@ -71,18 +71,18 @@ impl<D: Hash, G: Group> KeyExchange<D, G> for TripleDH {
     }
 
     #[allow(clippy::type_complexity)]
-    fn generate_ke2<R: RngCore + CryptoRng, S: SecretKey<G>>(
+    fn generate_ke2<R: RngCore + CryptoRng, S: SecretKey<A>>(
         rng: &mut R,
         serialized_credential_request: Vec<u8>,
         l2_bytes: Vec<u8>,
         ke1_message: Self::KE1Message,
-        client_s_pk: PublicKey<G>,
+        client_s_pk: PublicKey<A>,
         server_s_sk: S,
         id_u: Vec<u8>,
         id_s: Vec<u8>,
         context: Vec<u8>,
-    ) -> Result<GenerateKe2Result<Self, D, G>, ProtocolError<S::Error>> {
-        let server_e_kp = KeyPair::<G>::generate_random(rng);
+    ) -> Result<GenerateKe2Result<Self, D, A>, ProtocolError<S::Error>> {
+        let server_e_kp = KeyPair::<A>::generate_random(rng);
         let server_nonce = generate_nonce::<R>(rng);
 
         let mut transcript_hasher = D::new()
@@ -95,7 +95,7 @@ impl<D: Hash, G: Group> KeyExchange<D, G> for TripleDH {
             .chain(&server_nonce[..])
             .chain(&server_e_kp.public().to_arr());
 
-        let result = derive_3dh_keys::<D, G, S>(
+        let result = derive_3dh_keys::<D, A, S>(
             TripleDHComponents {
                 pk1: ke1_message.client_e_pk.clone(),
                 sk1: server_e_kp.private().clone(),
@@ -138,12 +138,12 @@ impl<D: Hash, G: Group> KeyExchange<D, G> for TripleDH {
         ke2_message: Self::KE2Message,
         ke1_state: &Self::KE1State,
         serialized_credential_request: &[u8],
-        server_s_pk: PublicKey<G>,
-        client_s_sk: PrivateKey<G>,
+        server_s_pk: PublicKey<A>,
+        client_s_sk: PrivateKey<A>,
         id_u: Vec<u8>,
         id_s: Vec<u8>,
         context: Vec<u8>,
-    ) -> Result<GenerateKe3Result<Self, D, G>, ProtocolError> {
+    ) -> Result<GenerateKe3Result<Self, D, A>, ProtocolError> {
         let mut transcript_hasher = D::new()
             .chain(STR_RFC)
             .chain(&serialize(&context, 2)?)
@@ -153,7 +153,7 @@ impl<D: Hash, G: Group> KeyExchange<D, G> for TripleDH {
             .chain(&l2_component[..])
             .chain(&ke2_message.to_bytes_without_info_or_mac());
 
-        let result = derive_3dh_keys::<D, G, PrivateKey<G>>(
+        let result = derive_3dh_keys::<D, A, PrivateKey<A>>(
             TripleDHComponents {
                 pk1: ke2_message.server_e_pk.clone(),
                 sk1: ke1_state.client_e_sk.clone(),
@@ -213,52 +213,54 @@ impl<D: Hash, G: Group> KeyExchange<D, G> for TripleDH {
 
     fn ke2_message_size() -> usize {
         NonceLen::to_usize()
-            + <G as Group>::ElemLen::to_usize()
+            + <A as Ake>::PkLen::to_usize()
             + <<D as FixedOutput>::OutputSize as Unsigned>::to_usize()
     }
 }
 
 /// The client state produced after the first key exchange message
 #[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
-pub struct Ke1State<G: Group> {
-    client_e_sk: PrivateKey<G>,
+pub struct Ke1State<A: Ake> {
+    client_e_sk: PrivateKey<A>,
     client_nonce: GenericArray<u8, NonceLen>,
 }
 
 impl_clone_for!(
-    struct Ke1State<G: Group>,
+    struct Ke1State<A: Ake>,
     [client_e_sk, client_nonce],
 );
 impl_debug_eq_hash_for!(
-    struct Ke1State<G: Group>,
+    struct Ke1State<A: Ake>,
     [client_e_sk, client_nonce],
 );
 
 // This can't be derived because of the use of a generic parameter
-impl<G: Group> Zeroize for Ke1State<G> {
+impl<A: Ake> Zeroize for Ke1State<A> {
     fn zeroize(&mut self) {
         self.client_e_sk.zeroize();
         self.client_nonce.zeroize();
     }
 }
 
-impl<G: Group> Drop for Ke1State<G> {
+impl<A: Ake> Drop for Ke1State<A> {
     fn drop(&mut self) {
         self.zeroize();
     }
 }
 
 /// The first key exchange message
-#[derive(PartialEq, Eq, Debug, Hash, Clone)]
 #[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
-pub struct Ke1Message<G: Group> {
+pub struct Ke1Message<A: Ake> {
     pub(crate) client_nonce: GenericArray<u8, NonceLen>,
-    pub(crate) client_e_pk: PublicKey<G>,
+    pub(crate) client_e_pk: PublicKey<A>,
 }
 
-impl<G: Group> FromBytes for Ke1State<G> {
+impl_debug_eq_hash_for!(struct Ke1Message<A: Ake>, [client_nonce, client_e_pk]);
+impl_clone_for!(struct Ke1Message<A: Ake>, [client_nonce, client_e_pk]);
+
+impl<A: Ake> FromBytes for Ke1State<A> {
     fn from_bytes<CS: CipherSuite>(bytes: &[u8]) -> Result<Self, PakeError> {
-        let key_len = <G as Group>::ElemLen::to_usize();
+        let key_len = <A as Ake>::PkLen::to_usize();
 
         let nonce_len = NonceLen::to_usize();
         let checked_bytes = check_slice_size_atleast(bytes, key_len + nonce_len, "ke1_state")?;
@@ -272,7 +274,7 @@ impl<G: Group> FromBytes for Ke1State<G> {
     }
 }
 
-impl<G: Group> ToBytesWithPointers for Ke1State<G> {
+impl<A: Ake> ToBytesWithPointers for Ke1State<A> {
     fn to_bytes(&self) -> Vec<u8> {
         let output: Vec<u8> = [&self.client_e_sk.to_arr(), &self.client_nonce[..]].concat();
         output
@@ -283,25 +285,25 @@ impl<G: Group> ToBytesWithPointers for Ke1State<G> {
         vec![
             (
                 self.client_e_sk.as_ptr(),
-                <PrivateKey<G> as SizedBytes>::Len::to_usize(),
+                <PrivateKey<A> as SizedBytes>::Len::to_usize(),
             ),
             (self.client_nonce.as_ptr(), NonceLen::to_usize()),
         ]
     }
 }
 
-impl<G: Group> ToBytes for Ke1Message<G> {
+impl<A: Ake> ToBytes for Ke1Message<A> {
     fn to_bytes(&self) -> Vec<u8> {
         [&self.client_nonce[..], &self.client_e_pk.to_arr()].concat()
     }
 }
 
-impl<G: Group> FromBytes for Ke1Message<G> {
+impl<A: Ake> FromBytes for Ke1Message<A> {
     fn from_bytes<CS: CipherSuite>(ke1_message_bytes: &[u8]) -> Result<Self, PakeError> {
         let nonce_len = NonceLen::to_usize();
         let checked_nonce = check_slice_size(
             ke1_message_bytes,
-            nonce_len + <G as Group>::ElemLen::to_usize(),
+            nonce_len + <A as Ake>::PkLen::to_usize(),
             "ke1_message nonce",
         )?;
 
@@ -357,13 +359,23 @@ impl<HashLen: ArrayLength<u8>> ToBytesWithPointers for Ke2State<HashLen> {
 }
 
 /// The second key exchange message
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serialize", serde(bound = ""))]
-pub struct Ke2Message<G: Group, HashLen: ArrayLength<u8>> {
+pub struct Ke2Message<A: Ake, HashLen: ArrayLength<u8>> {
     server_nonce: GenericArray<u8, NonceLen>,
-    server_e_pk: PublicKey<G>,
+    server_e_pk: PublicKey<A>,
     mac: GenericArray<u8, HashLen>,
+}
+
+impl<A: Ake, HashLen: ArrayLength<u8>> Clone for Ke2Message<A, HashLen> {
+    fn clone(&self) -> Self {
+        Self {
+            server_nonce: self.server_nonce,
+            server_e_pk: self.server_e_pk.clone(),
+            mac: self.mac.clone(),
+        }
+    }
 }
 
 impl<HashLen: ArrayLength<u8>> FromBytes for Ke2State<HashLen> {
@@ -381,21 +393,21 @@ impl<HashLen: ArrayLength<u8>> FromBytes for Ke2State<HashLen> {
     }
 }
 
-impl<G: Group, HashLen: ArrayLength<u8>> ToBytes for Ke2Message<G, HashLen> {
+impl<A: Ake, HashLen: ArrayLength<u8>> ToBytes for Ke2Message<A, HashLen> {
     fn to_bytes(&self) -> Vec<u8> {
         [&self.to_bytes_without_info_or_mac(), &self.mac[..]].concat()
     }
 }
 
-impl<G: Group, HashLen: ArrayLength<u8>> Ke2Message<G, HashLen> {
+impl<A: Ake, HashLen: ArrayLength<u8>> Ke2Message<A, HashLen> {
     fn to_bytes_without_info_or_mac(&self) -> Vec<u8> {
         [&self.server_nonce[..], &self.server_e_pk.to_arr()].concat()
     }
 }
 
-impl<G: Group, HashLen: ArrayLength<u8>> FromBytes for Ke2Message<G, HashLen> {
+impl<A: Ake, HashLen: ArrayLength<u8>> FromBytes for Ke2Message<A, HashLen> {
     fn from_bytes<CS: CipherSuite>(input: &[u8]) -> Result<Self, PakeError> {
-        let key_len = <G as Group>::ElemLen::to_usize();
+        let key_len = <A as Ake>::PkLen::to_usize();
         let nonce_len = NonceLen::to_usize();
         let checked_nonce = check_slice_size_atleast(input, nonce_len, "ke2_message nonce")?;
 
@@ -411,7 +423,7 @@ impl<G: Group, HashLen: ArrayLength<u8>> FromBytes for Ke2Message<G, HashLen> {
         )?;
 
         // Check the public key bytes
-        let server_e_pk = KeyPair::<CS::Group>::check_public_key(PublicKey::from_bytes(
+        let server_e_pk = KeyPair::<CS::Ake>::check_public_key(PublicKey::from_bytes(
             &unchecked_server_e_pk[..key_len],
         )?)?;
 
@@ -425,13 +437,13 @@ impl<G: Group, HashLen: ArrayLength<u8>> FromBytes for Ke2Message<G, HashLen> {
 
 #[allow(clippy::upper_case_acronyms)]
 // The triple of public and private components used in the 3DH computation
-struct TripleDHComponents<G: Group, S: SecretKey<G>> {
-    pk1: PublicKey<G>,
-    sk1: PrivateKey<G>,
-    pk2: PublicKey<G>,
+struct TripleDHComponents<A: Ake, S: SecretKey<A>> {
+    pk1: PublicKey<A>,
+    sk1: PrivateKey<A>,
+    pk2: PublicKey<A>,
     sk2: S,
-    pk3: PublicKey<G>,
-    sk3: PrivateKey<G>,
+    pk3: PublicKey<A>,
+    sk3: PrivateKey<A>,
 }
 
 // Consists of a session key, followed by two mac keys: (session_key, km2, km3)
@@ -478,8 +490,8 @@ impl<HashLen: ArrayLength<u8>> FromBytes for Ke3Message<HashLen> {
 
 // Internal function which takes the public and private components of the client and server keypairs, along
 // with some auxiliary metadata, to produce the session key and two MAC keys
-fn derive_3dh_keys<D: Hash, G: Group, S: SecretKey<G>>(
-    dh: TripleDHComponents<G, S>,
+fn derive_3dh_keys<D: Hash, A: Ake, S: SecretKey<A>>(
+    dh: TripleDHComponents<A, S>,
     hashed_derivation_transcript: &[u8],
 ) -> Result<TripleDHDerivationResult<D>, ProtocolError<S::Error>> {
     let ikm: Vec<u8> = [

--- a/src/key_exchange/tripledh.rs
+++ b/src/key_exchange/tripledh.rs
@@ -283,10 +283,7 @@ impl<A: Ake> ToBytesWithPointers for Ke1State<A> {
     #[cfg(test)]
     fn as_byte_ptrs(&self) -> Vec<(*const u8, usize)> {
         vec![
-            (
-                self.client_e_sk.as_ptr(),
-                <PrivateKey<A> as SizedBytes>::Len::to_usize(),
-            ),
+            (self.client_e_sk.as_ptr(), A::SkLen::to_usize()),
             (self.client_nonce.as_ptr(), NonceLen::to_usize()),
         ]
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 //! use opaque_ke::CipherSuite;
 //! struct Default;
 //! impl CipherSuite for Default {
+//!     type Ake = curve25519_dalek::ristretto::RistrettoPoint;
 //!     type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //!     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
 //!     type Hash = sha2::Sha512;
@@ -47,6 +48,7 @@
 //! # use opaque_ke::ServerSetup;
 //! # struct Default;
 //! # impl CipherSuite for Default {
+//! #     type Ake = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
 //! #     type Hash = sha2::Sha512;
@@ -79,6 +81,7 @@
 //! # use opaque_ke::CipherSuite;
 //! # struct Default;
 //! # impl CipherSuite for Default {
+//! #     type Ake = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
 //! #     type Hash = sha2::Sha512;
@@ -109,6 +112,7 @@
 //! # use opaque_ke::CipherSuite;
 //! # struct Default;
 //! # impl CipherSuite for Default {
+//! #     type Ake = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
 //! #     type Hash = sha2::Sha512;
@@ -146,6 +150,7 @@
 //! # use opaque_ke::CipherSuite;
 //! # struct Default;
 //! # impl CipherSuite for Default {
+//! #     type Ake = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
 //! #     type Hash = sha2::Sha512;
@@ -184,6 +189,7 @@
 //! # use opaque_ke::CipherSuite;
 //! # struct Default;
 //! # impl CipherSuite for Default {
+//! #     type Ake = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
 //! #     type Hash = sha2::Sha512;
@@ -226,6 +232,7 @@
 //! # use opaque_ke::CipherSuite;
 //! # struct Default;
 //! # impl CipherSuite for Default {
+//! #     type Ake = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
 //! #     type Hash = sha2::Sha512;
@@ -259,6 +266,7 @@
 //! # use opaque_ke::CipherSuite;
 //! # struct Default;
 //! # impl CipherSuite for Default {
+//! #     type Ake = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
 //! #     type Hash = sha2::Sha512;
@@ -312,6 +320,7 @@
 //! # use opaque_ke::CipherSuite;
 //! # struct Default;
 //! # impl CipherSuite for Default {
+//! #     type Ake = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
 //! #     type Hash = sha2::Sha512;
@@ -357,6 +366,7 @@
 //! # use opaque_ke::CipherSuite;
 //! # struct Default;
 //! # impl CipherSuite for Default {
+//! #     type Ake = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
 //! #     type Hash = sha2::Sha512;
@@ -432,6 +442,7 @@
 //! # use opaque_ke::CipherSuite;
 //! # struct Default;
 //! # impl CipherSuite for Default {
+//! #     type Ake = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
 //! #     type Hash = sha2::Sha512;
@@ -509,6 +520,7 @@
 //! # use opaque_ke::CipherSuite;
 //! # struct Default;
 //! # impl CipherSuite for Default {
+//! #     type Ake = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
 //! #     type Hash = sha2::Sha512;
@@ -574,6 +586,7 @@
 //! # use opaque_ke::CipherSuite;
 //! # struct Default;
 //! # impl CipherSuite for Default {
+//! #     type Ake = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
 //! #     type Hash = sha2::Sha512;
@@ -611,6 +624,7 @@
 //! # use opaque_ke::CipherSuite;
 //! # struct Default;
 //! # impl CipherSuite for Default {
+//! #     type Ake = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
 //! #     type Hash = sha2::Sha512;
@@ -660,6 +674,7 @@
 //! # use opaque_ke::CipherSuite;
 //! # struct Default;
 //! # impl CipherSuite for Default {
+//! #     type Ake = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type Group = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
 //! #     type Hash = sha2::Sha512;
@@ -737,6 +752,7 @@
 //! # use zeroize::Zeroize;
 //! # struct Default;
 //! # impl CipherSuite for Default {
+//! #     type Ake = curve25519_dalek::ristretto::RistrettoPoint;
 //! #     type Group = RistrettoPoint;
 //! #     type KeyExchange = opaque_ke::key_exchange::tripledh::TripleDH;
 //! #     type Hash = sha2::Sha512;
@@ -830,6 +846,7 @@ pub mod ciphersuite;
 mod envelope;
 pub mod hash;
 
+pub mod ake;
 pub mod group;
 
 pub mod key_exchange;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -79,7 +79,7 @@ pub struct RegistrationResponse<CS: CipherSuite> {
     /// The server's oprf output
     pub(crate) beta: CS::Group,
     /// Server's static public key
-    pub(crate) server_s_pk: PublicKey<CS::Group>,
+    pub(crate) server_s_pk: PublicKey<CS::Ake>,
 }
 
 // Cannot be derived because it would require for CS to be Clone.
@@ -107,7 +107,7 @@ impl<CS: CipherSuite> RegistrationResponse<CS> {
     /// Deserialization from bytes
     pub fn deserialize(input: &[u8]) -> Result<Self, ProtocolError> {
         let elem_len = <CS::Group as Group>::ElemLen::to_usize();
-        let key_len = <PublicKey<CS::Group> as SizedBytes>::Len::to_usize();
+        let key_len = <PublicKey<CS::Ake> as SizedBytes>::Len::to_usize();
         let checked_slice =
             check_slice_size(input, elem_len + key_len, "registration_response_bytes")?;
 
@@ -122,7 +122,7 @@ impl<CS: CipherSuite> RegistrationResponse<CS> {
         }
 
         // Ensure that public key is valid
-        let server_s_pk = KeyPair::<CS::Group>::check_public_key(PublicKey::from_bytes(
+        let server_s_pk = KeyPair::<CS::Ake>::check_public_key(PublicKey::from_bytes(
             &checked_slice[elem_len..],
         )?)?;
 
@@ -151,7 +151,7 @@ pub struct RegistrationUpload<CS: CipherSuite> {
     /// The masking key used to mask the envelope
     pub(crate) masking_key: GenericArray<u8, <CS::Hash as Digest>::OutputSize>,
     /// The user's public key
-    pub(crate) client_s_pk: PublicKey<CS::Group>,
+    pub(crate) client_s_pk: PublicKey<CS::Ake>,
 }
 
 impl_clone_for!(
@@ -176,7 +176,7 @@ impl<CS: CipherSuite> RegistrationUpload<CS> {
 
     /// Deserialization from bytes
     pub fn deserialize(input: &[u8]) -> Result<Self, ProtocolError> {
-        let key_len = <PublicKey<CS::Group> as SizedBytes>::Len::to_usize();
+        let key_len = <PublicKey<CS::Ake> as SizedBytes>::Len::to_usize();
         let hash_len = <CS::Hash as Digest>::OutputSize::to_usize();
         let checked_slice =
             check_slice_size_atleast(input, key_len + hash_len, "registration_upload_bytes")?;
@@ -186,14 +186,14 @@ impl<CS: CipherSuite> RegistrationUpload<CS> {
             masking_key: GenericArray::clone_from_slice(
                 &checked_slice[key_len..key_len + hash_len],
             ),
-            client_s_pk: KeyPair::<CS::Group>::check_public_key(PublicKey::from_bytes(
+            client_s_pk: KeyPair::<CS::Ake>::check_public_key(PublicKey::from_bytes(
                 &checked_slice[..key_len],
             )?)?,
         })
     }
 
     // Creates a dummy instance used for faking a [CredentialResponse]
-    pub(crate) fn dummy<R: RngCore + CryptoRng, S: SecretKey<CS::Group>>(
+    pub(crate) fn dummy<R: RngCore + CryptoRng, S: SecretKey<CS::Ake>>(
         rng: &mut R,
         server_setup: &ServerSetup<CS, S>,
     ) -> Self {
@@ -214,7 +214,7 @@ impl_serialize_and_deserialize_for!(RegistrationUpload);
 pub struct CredentialRequest<CS: CipherSuite> {
     /// blinded password information
     pub(crate) alpha: CS::Group,
-    pub(crate) ke1_message: <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE1Message,
+    pub(crate) ke1_message: <CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::KE1Message,
 }
 
 // Cannot be derived because it would require for CS to be Clone.
@@ -232,7 +232,7 @@ impl_debug_eq_hash_for!(
     [alpha, ke1_message],
     [
         CS::Group,
-        <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE1Message
+        <CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::KE1Message
     ],
 );
 
@@ -259,7 +259,7 @@ impl<CS: CipherSuite> CredentialRequest<CS> {
         }
 
         let ke1_message =
-            <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE1Message::from_bytes::<CS>(
+            <CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::KE1Message::from_bytes::<CS>(
                 &checked_slice[elem_len..],
             )?;
 
@@ -282,7 +282,7 @@ pub struct CredentialResponse<CS: CipherSuite> {
     pub(crate) beta: CS::Group,
     pub(crate) masking_nonce: Vec<u8>,
     pub(crate) masked_response: Vec<u8>,
-    pub(crate) ke2_message: <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE2Message,
+    pub(crate) ke2_message: <CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::KE2Message,
 }
 
 // Cannot be derived because it would require for CS to be Clone.
@@ -302,7 +302,7 @@ impl_debug_eq_hash_for!(
     [beta, masking_nonce, masked_response, ke2_message],
     [
         CS::Group,
-        <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE2Message,
+        <CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::KE2Message,
     ],
 );
 
@@ -327,7 +327,7 @@ impl<CS: CipherSuite> CredentialResponse<CS> {
     /// Deserialization from bytes
     pub fn deserialize(input: &[u8]) -> Result<Self, ProtocolError> {
         let elem_len = <CS::Group as Group>::ElemLen::to_usize();
-        let key_len = <PublicKey<CS::Group> as SizedBytes>::Len::to_usize();
+        let key_len = <PublicKey<CS::Ake> as SizedBytes>::Len::to_usize();
         let nonce_len: usize = 32;
         let envelope_len = Envelope::<CS>::len();
         let masked_response_len = key_len + envelope_len;
@@ -355,7 +355,7 @@ impl<CS: CipherSuite> CredentialResponse<CS> {
             [elem_len + nonce_len..elem_len + nonce_len + masked_response_len]
             .to_vec();
         let ke2_message =
-            <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE2Message::from_bytes::<CS>(
+            <CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::KE2Message::from_bytes::<CS>(
                 &checked_slice[elem_len + nonce_len + masked_response_len..],
             )?;
 
@@ -385,14 +385,14 @@ impl_serialize_and_deserialize_for!(CredentialResponse);
 /// The answer sent by the client to the server, upon reception of the
 /// sealed envelope
 pub struct CredentialFinalization<CS: CipherSuite> {
-    pub(crate) ke3_message: <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE3Message,
+    pub(crate) ke3_message: <CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::KE3Message,
 }
 
 impl_clone_for!(struct CredentialFinalization<CS: CipherSuite>, [ke3_message]);
 impl_debug_eq_hash_for!(
     struct CredentialFinalization<CS: CipherSuite>,
     [ke3_message],
-    [<CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE3Message],
+    [<CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::KE3Message],
 );
 
 impl<CS: CipherSuite> CredentialFinalization<CS> {
@@ -404,7 +404,7 @@ impl<CS: CipherSuite> CredentialFinalization<CS> {
     /// Deserialization from bytes
     pub fn deserialize(input: &[u8]) -> Result<Self, ProtocolError> {
         let ke3_message =
-            <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE3Message::from_bytes::<CS>(
+            <CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::KE3Message::from_bytes::<CS>(
                 input,
             )?;
         Ok(Self { ke3_message })

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -6,6 +6,7 @@
 //! Contains the messages used for OPAQUE
 
 use crate::{
+    ake::Ake,
     ciphersuite::CipherSuite,
     envelope::Envelope,
     errors::{
@@ -107,7 +108,7 @@ impl<CS: CipherSuite> RegistrationResponse<CS> {
     /// Deserialization from bytes
     pub fn deserialize(input: &[u8]) -> Result<Self, ProtocolError> {
         let elem_len = <CS::Group as Group>::ElemLen::to_usize();
-        let key_len = <PublicKey<CS::Ake> as SizedBytes>::Len::to_usize();
+        let key_len = <CS::Ake as Ake>::PkLen::to_usize();
         let checked_slice =
             check_slice_size(input, elem_len + key_len, "registration_response_bytes")?;
 
@@ -176,7 +177,7 @@ impl<CS: CipherSuite> RegistrationUpload<CS> {
 
     /// Deserialization from bytes
     pub fn deserialize(input: &[u8]) -> Result<Self, ProtocolError> {
-        let key_len = <PublicKey<CS::Ake> as SizedBytes>::Len::to_usize();
+        let key_len = <CS::Ake as Ake>::PkLen::to_usize();
         let hash_len = <CS::Hash as Digest>::OutputSize::to_usize();
         let checked_slice =
             check_slice_size_atleast(input, key_len + hash_len, "registration_upload_bytes")?;
@@ -327,7 +328,7 @@ impl<CS: CipherSuite> CredentialResponse<CS> {
     /// Deserialization from bytes
     pub fn deserialize(input: &[u8]) -> Result<Self, ProtocolError> {
         let elem_len = <CS::Group as Group>::ElemLen::to_usize();
-        let key_len = <PublicKey<CS::Ake> as SizedBytes>::Len::to_usize();
+        let key_len = <CS::Ake as Ake>::PkLen::to_usize();
         let nonce_len: usize = 32;
         let envelope_len = Envelope::<CS>::len();
         let masked_response_len = key_len + envelope_len;

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -6,6 +6,7 @@
 //! Provides the main OPAQUE API
 
 use crate::{
+    ake::Ake,
     ciphersuite::CipherSuite,
     envelope::Envelope,
     errors::{utils::check_slice_size, InternalPakeError, PakeError, ProtocolError},
@@ -87,7 +88,7 @@ impl<CS: CipherSuite, S: SecretKey<CS::Ake>> ServerSetup<CS, S> {
     /// Deserialization from bytes
     pub fn deserialize(input: &[u8]) -> Result<Self, ProtocolError<S::Error>> {
         let seed_len = <CS::Hash as Digest>::OutputSize::to_usize();
-        let key_len = <PrivateKey<CS::Ake> as SizedBytes>::Len::to_usize();
+        let key_len = <CS::Ake as Ake>::SkLen::to_usize();
         let checked_slice = check_slice_size(input, seed_len + key_len + key_len, "server_setup")?;
 
         Ok(Self {

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -40,40 +40,37 @@ const STR_OPAQUE_DERIVE_KEY_PAIR: &[u8] = b"OPAQUE-DeriveKeyPair";
     feature = "serialize",
     derive(serde::Deserialize, serde::Serialize),
     serde(bound(
-        deserialize = "KeyPair<CS::Group, S>: serde::Deserialize<'de>",
-        serialize = "KeyPair<CS::Group, S>: serde::Serialize"
+        deserialize = "KeyPair<CS::Ake, S>: serde::Deserialize<'de>",
+        serialize = "KeyPair<CS::Ake, S>: serde::Serialize"
     ))
 )]
 pub struct ServerSetup<
     CS: CipherSuite,
-    S: SecretKey<CS::Group> = PrivateKey<<CS as CipherSuite>::Group>,
+    S: SecretKey<CS::Ake> = PrivateKey<<CS as CipherSuite>::Ake>,
 > {
     oprf_seed: GenericArray<u8, <CS::Hash as Digest>::OutputSize>,
-    keypair: KeyPair<CS::Group, S>,
-    pub(crate) fake_keypair: KeyPair<CS::Group>,
+    keypair: KeyPair<CS::Ake, S>,
+    pub(crate) fake_keypair: KeyPair<CS::Ake>,
 }
 
-impl<CS: CipherSuite> ServerSetup<CS, PrivateKey<CS::Group>> {
+impl<CS: CipherSuite> ServerSetup<CS, PrivateKey<CS::Ake>> {
     /// Generate a new instance of server setup
     pub fn new<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
-        let keypair = KeyPair::<CS::Group>::generate_random(rng);
+        let keypair = KeyPair::<CS::Ake>::generate_random(rng);
         Self::new_with_key(rng, keypair)
     }
 }
 
-impl<CS: CipherSuite, S: SecretKey<CS::Group>> ServerSetup<CS, S> {
+impl<CS: CipherSuite, S: SecretKey<CS::Ake>> ServerSetup<CS, S> {
     /// Create [`ServerSetup`] with the given keypair
-    pub fn new_with_key<R: CryptoRng + RngCore>(
-        rng: &mut R,
-        keypair: KeyPair<CS::Group, S>,
-    ) -> Self {
+    pub fn new_with_key<R: CryptoRng + RngCore>(rng: &mut R, keypair: KeyPair<CS::Ake, S>) -> Self {
         let mut seed = vec![0u8; <CS::Hash as Digest>::OutputSize::to_usize()];
         rng.fill_bytes(&mut seed);
 
         Self {
             oprf_seed: GenericArray::clone_from_slice(&seed[..]),
             keypair,
-            fake_keypair: KeyPair::<CS::Group>::generate_random(rng),
+            fake_keypair: KeyPair::<CS::Ake>::generate_random(rng),
         }
     }
 
@@ -90,7 +87,7 @@ impl<CS: CipherSuite, S: SecretKey<CS::Group>> ServerSetup<CS, S> {
     /// Deserialization from bytes
     pub fn deserialize(input: &[u8]) -> Result<Self, ProtocolError<S::Error>> {
         let seed_len = <CS::Hash as Digest>::OutputSize::to_usize();
-        let key_len = <PrivateKey<CS::Group> as SizedBytes>::Len::to_usize();
+        let key_len = <PrivateKey<CS::Ake> as SizedBytes>::Len::to_usize();
         let checked_slice = check_slice_size(input, seed_len + key_len + key_len, "server_setup")?;
 
         Ok(Self {
@@ -102,7 +99,7 @@ impl<CS: CipherSuite, S: SecretKey<CS::Group>> ServerSetup<CS, S> {
     }
 
     /// Returns the keypair
-    pub fn keypair(&self) -> &KeyPair<CS::Group, S> {
+    pub fn keypair(&self) -> &KeyPair<CS::Ake, S> {
         &self.keypair
     }
 }
@@ -273,7 +270,7 @@ pub struct ClientRegistrationFinishResult<CS: CipherSuite> {
     /// The export key output by client registration
     pub export_key: GenericArray<u8, <CS::Hash as Digest>::OutputSize>,
     /// The server's static public key
-    pub server_s_pk: PublicKey<CS::Group>,
+    pub server_s_pk: PublicKey<CS::Ake>,
     /// Instance of the ClientRegistration, only used in tests for checking zeroize
     #[cfg(test)]
     pub state: ClientRegistration<CS>,
@@ -403,7 +400,7 @@ impl<CS: CipherSuite> ServerRegistration<CS> {
 
     /// From the client's "blinded" password, returns a response to be
     /// sent back to the client, as well as a ServerRegistration
-    pub fn start<S: SecretKey<CS::Group>>(
+    pub fn start<S: SecretKey<CS::Ake>>(
         server_setup: &ServerSetup<CS, S>,
         message: RegistrationRequest<CS>,
         credential_identifier: &[u8],
@@ -433,7 +430,7 @@ impl<CS: CipherSuite> ServerRegistration<CS> {
     }
 
     // Creates a dummy instance used for faking a [CredentialResponse]
-    pub(crate) fn dummy<R: RngCore + CryptoRng, S: SecretKey<CS::Group>>(
+    pub(crate) fn dummy<R: RngCore + CryptoRng, S: SecretKey<CS::Ake>>(
         rng: &mut R,
         server_setup: &ServerSetup<CS, S>,
     ) -> Self {
@@ -451,14 +448,14 @@ impl_serialize_and_deserialize_for!(ServerRegistration);
 #[cfg_attr(
     feature = "serialize",
     serde(bound(
-        deserialize = "oprf::Token<CS::Group>: serde::Deserialize<'de>, <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE1State: serde::Deserialize<'de>",
-        serialize = "oprf::Token<CS::Group>: serde::Serialize, <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE1State: serde::Serialize"
+        deserialize = "oprf::Token<CS::Group>: serde::Deserialize<'de>, <CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::KE1State: serde::Deserialize<'de>",
+        serialize = "oprf::Token<CS::Group>: serde::Serialize, <CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::KE1State: serde::Serialize"
     ))
 )]
 pub struct ClientLogin<CS: CipherSuite> {
     /// token containing the client's password and the blinding factor
     token: oprf::Token<CS::Group>,
-    ke1_state: <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE1State,
+    ke1_state: <CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::KE1State,
     serialized_credential_request: Vec<u8>,
 }
 
@@ -466,7 +463,7 @@ impl_clone_for!(struct ClientLogin<CS: CipherSuite>, [token, ke1_state, serializ
 impl_debug_eq_hash_for!(
     struct ClientLogin<CS: CipherSuite>,
     [token, ke1_state, serialized_credential_request],
-    [oprf::Token<CS::Group>, <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE1State],
+    [oprf::Token<CS::Group>, <CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::KE1State],
 );
 
 impl<CS: CipherSuite> ClientLogin<CS> {
@@ -501,10 +498,9 @@ impl<CS: CipherSuite> ClientLogin<CS> {
         let (serialized_credential_request, remainder) = tokenize(&checked_slice[scalar_len..], 2)?;
         let (ke1_state_bytes, password) = tokenize(&remainder, 2)?;
 
-        let ke1_state =
-            <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE1State::from_bytes::<CS>(
-                &ke1_state_bytes[..],
-            )?;
+        let ke1_state = <CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::KE1State::from_bytes::<
+            CS,
+        >(&ke1_state_bytes[..])?;
         Ok(Self {
             token: oprf::Token {
                 data: password,
@@ -575,7 +571,7 @@ pub struct ClientLoginFinishResult<CS: CipherSuite> {
     /// The client-side export key
     pub export_key: GenericArray<u8, <CS::Hash as Digest>::OutputSize>,
     /// The server's static public key
-    pub server_s_pk: PublicKey<CS::Group>,
+    pub server_s_pk: PublicKey<CS::Ake>,
     /// Instance of the ClientLogin, only used in tests for checking zeroize
     #[cfg(test)]
     pub state: ClientLogin<CS>,
@@ -722,7 +718,7 @@ impl<CS: CipherSuite> ClientLogin<CS> {
 
 /// The state elements the server holds to record a login
 pub struct ServerLogin<CS: CipherSuite> {
-    ke2_state: <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE2State,
+    ke2_state: <CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::KE2State,
     _cs: PhantomData<CS>,
 }
 
@@ -730,7 +726,7 @@ impl_clone_for!(struct ServerLogin<CS: CipherSuite>, [ke2_state, _cs]);
 impl_debug_eq_hash_for!(
     struct ServerLogin<CS: CipherSuite>,
     [ke2_state, _cs],
-    [<CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE2State],
+    [<CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::KE2State],
 );
 
 /// Optional parameters for server login start
@@ -817,7 +813,7 @@ impl<CS: CipherSuite> ServerLogin<CS> {
     pub fn deserialize(bytes: &[u8]) -> Result<Self, ProtocolError> {
         Ok(Self {
             _cs: PhantomData,
-            ke2_state: <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::KE2State::from_bytes::<
+            ke2_state: <CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::KE2State::from_bytes::<
                 CS,
             >(bytes)?,
         })
@@ -825,7 +821,7 @@ impl<CS: CipherSuite> ServerLogin<CS> {
 
     /// From the client's "blinded" password, returns a challenge to be
     /// sent back to the client, as well as a ServerLogin
-    pub fn start<R: RngCore + CryptoRng, S: SecretKey<CS::Group>>(
+    pub fn start<R: RngCore + CryptoRng, S: SecretKey<CS::Ake>>(
         rng: &mut R,
         server_setup: &ServerSetup<CS, S>,
         password_file: Option<ServerRegistration<CS>>,
@@ -921,7 +917,7 @@ impl<CS: CipherSuite> ServerLogin<CS> {
         self,
         message: CredentialFinalization<CS>,
     ) -> Result<ServerLoginFinishResult<CS>, ProtocolError> {
-        let session_key = <CS::KeyExchange as KeyExchange<CS::Hash, CS::Group>>::finish_ke(
+        let session_key = <CS::KeyExchange as KeyExchange<CS::Hash, CS::Ake>>::finish_ke(
             message.ke3_message,
             &self.ke2_state,
         )
@@ -1022,7 +1018,7 @@ fn oprf_key_from_seed<G: Group, D: Hash>(
     oprf_seed: &GenericArray<u8, D::OutputSize>,
     credential_identifier: &[u8],
 ) -> Result<G::Scalar, ProtocolError> {
-    let mut ikm = vec![0u8; <PrivateKey<G> as SizedBytes>::Len::to_usize()];
+    let mut ikm = vec![0u8; G::ScalarLen::to_usize()];
     Hkdf::<D>::from_prk(oprf_seed)
         .map_err(|_| InternalPakeError::HkdfError)?
         .expand(&[credential_identifier, STR_OPRF_KEY].concat(), &mut ikm)
@@ -1033,11 +1029,10 @@ fn oprf_key_from_seed<G: Group, D: Hash>(
 fn mask_response<CS: CipherSuite>(
     masking_key: &[u8],
     masking_nonce: &[u8],
-    server_s_pk: &PublicKey<CS::Group>,
+    server_s_pk: &PublicKey<CS::Ake>,
     envelope: &Envelope<CS>,
 ) -> Result<Vec<u8>, ProtocolError> {
-    let mut xor_pad =
-        vec![0u8; <PublicKey<CS::Group> as SizedBytes>::Len::to_usize() + Envelope::<CS>::len()];
+    let mut xor_pad = vec![0u8; <CS::Group as Group>::ElemLen::to_usize() + Envelope::<CS>::len()];
     Hkdf::<CS::Hash>::from_prk(masking_key)
         .map_err(|_| InternalPakeError::HkdfError)?
         .expand(
@@ -1059,9 +1054,8 @@ fn unmask_response<CS: CipherSuite>(
     masking_key: &[u8],
     masking_nonce: &[u8],
     masked_response: &[u8],
-) -> Result<(PublicKey<CS::Group>, Envelope<CS>), ProtocolError> {
-    let mut xor_pad =
-        vec![0u8; <PublicKey<CS::Group> as SizedBytes>::Len::to_usize() + Envelope::<CS>::len()];
+) -> Result<(PublicKey<CS::Ake>, Envelope<CS>), ProtocolError> {
+    let mut xor_pad = vec![0u8; <CS::Group as Group>::ElemLen::to_usize() + Envelope::<CS>::len()];
     Hkdf::<CS::Hash>::from_prk(masking_key)
         .map_err(|_| InternalPakeError::HkdfError)?
         .expand(
@@ -1074,13 +1068,13 @@ fn unmask_response<CS: CipherSuite>(
         .zip(masked_response.iter())
         .map(|(&x1, &x2)| x1 ^ x2)
         .collect();
-    let key_len = <PublicKey<CS::Group> as SizedBytes>::Len::to_usize();
+    let key_len = <CS::Group as Group>::ElemLen::to_usize();
     let unchecked_server_s_pk =
         PublicKey::from_arr(&GenericArray::clone_from_slice(&plaintext[..key_len]))?;
     let envelope = Envelope::deserialize(&plaintext[key_len..])?;
 
     // Ensure that public key is valid
-    let server_s_pk = KeyPair::<CS::Group>::check_public_key(unchecked_server_s_pk)
+    let server_s_pk = KeyPair::<CS::Ake>::check_public_key(unchecked_server_s_pk)
         .map_err(|_| ProtocolError::VerificationError(PakeError::SerializationError))?;
 
     Ok((server_s_pk, envelope))

--- a/src/serialization/tests.rs
+++ b/src/serialization/tests.rs
@@ -12,7 +12,7 @@ use crate::{
         traits::{FromBytes, KeyExchange, ToBytes},
         tripledh::{NonceLen, TripleDH},
     },
-    keypair::{KeyPair, PublicKey},
+    keypair::KeyPair,
     serialization::{i2osp, os2ip, serialize},
     *,
 };
@@ -215,7 +215,7 @@ fn credential_response_roundtrip() {
 
     let mut masked_response = vec![
         0u8;
-        <PublicKey<RistrettoPoint> as SizedBytes>::Len::to_usize()
+        <RistrettoPoint as crate::ake::Ake>::PkLen::to_usize()
             + Envelope::<Default>::len()
     ];
     rng.fill_bytes(&mut masked_response);

--- a/src/tests/full_test.rs
+++ b/src/tests/full_test.rs
@@ -29,6 +29,7 @@ use zeroize::Zeroize;
 
 struct RistrettoSha5123dhNoSlowHash;
 impl CipherSuite for RistrettoSha5123dhNoSlowHash {
+    type Ake = RistrettoPoint;
     type Group = RistrettoPoint;
     type KeyExchange = TripleDH;
     type Hash = sha2::Sha512;
@@ -280,11 +281,11 @@ fn generate_parameters<CS: CipherSuite>() -> TestVectorParameters {
     let mut rng = OsRng;
 
     // Inputs
-    let server_s_kp = KeyPair::<CS::Group>::generate_random(&mut rng);
-    let server_e_kp = KeyPair::<CS::Group>::generate_random(&mut rng);
-    let client_s_kp = KeyPair::<CS::Group>::generate_random(&mut rng);
-    let client_e_kp = KeyPair::<CS::Group>::generate_random(&mut rng);
-    let fake_kp = KeyPair::<CS::Group>::generate_random(&mut rng);
+    let server_s_kp = KeyPair::<CS::Ake>::generate_random(&mut rng);
+    let server_e_kp = KeyPair::<CS::Ake>::generate_random(&mut rng);
+    let client_s_kp = KeyPair::<CS::Ake>::generate_random(&mut rng);
+    let client_e_kp = KeyPair::<CS::Ake>::generate_random(&mut rng);
+    let fake_kp = KeyPair::<CS::Ake>::generate_random(&mut rng);
     let credential_identifier = b"credIdentifier";
     let id_u = b"idU";
     let id_s = b"idS";

--- a/src/tests/opaque_test_vectors.rs
+++ b/src/tests/opaque_test_vectors.rs
@@ -4,12 +4,11 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{
-    ciphersuite::CipherSuite, errors::*, key_exchange::tripledh::TripleDH, keypair::PrivateKey,
-    opaque::*, slow_hash::NoOpHash, tests::mock_rng::CycleRng, *,
+    ake::Ake, ciphersuite::CipherSuite, errors::*, key_exchange::tripledh::TripleDH, opaque::*,
+    slow_hash::NoOpHash, tests::mock_rng::CycleRng, *,
 };
 use curve25519_dalek::ristretto::RistrettoPoint;
 use generic_array::typenum::Unsigned;
-use generic_bytes::SizedBytes;
 use serde_json::Value;
 
 // Tests
@@ -752,7 +751,7 @@ fn populate_test_vectors<CS: CipherSuite>(values: &Value) -> TestVectorParameter
         dummy_private_key: parse_default!(
             values,
             "client_private_key",
-            vec![0u8; <PrivateKey<CS::Ake> as SizedBytes>::Len::to_usize()]
+            vec![0u8; <CS::Ake as Ake>::SkLen::to_usize()]
         ),
         dummy_masking_key: parse_default!(values, "masking_key", vec![0u8; 64]),
         context: parse!(values, "Context"),

--- a/src/tests/opaque_test_vectors.rs
+++ b/src/tests/opaque_test_vectors.rs
@@ -17,6 +17,7 @@ use serde_json::Value;
 
 struct Ristretto255Sha512NoSlowHash;
 impl CipherSuite for Ristretto255Sha512NoSlowHash {
+    type Ake = RistrettoPoint;
     type Group = RistrettoPoint;
     type KeyExchange = TripleDH;
     type Hash = sha2::Sha512;
@@ -27,6 +28,7 @@ impl CipherSuite for Ristretto255Sha512NoSlowHash {
 struct P256Sha256NoSlowHash;
 #[cfg(feature = "p256")]
 impl CipherSuite for P256Sha256NoSlowHash {
+    type Ake = p256_::ProjectivePoint;
     type Group = p256_::ProjectivePoint;
     type KeyExchange = TripleDH;
     type Hash = sha2::Sha256;
@@ -750,7 +752,7 @@ fn populate_test_vectors<CS: CipherSuite>(values: &Value) -> TestVectorParameter
         dummy_private_key: parse_default!(
             values,
             "client_private_key",
-            vec![0u8; <PrivateKey<CS::Group> as SizedBytes>::Len::to_usize()]
+            vec![0u8; <PrivateKey<CS::Ake> as SizedBytes>::Len::to_usize()]
         ),
         dummy_masking_key: parse_default!(values, "masking_key", vec![0u8; 64]),
         context: parse!(values, "Context"),


### PR DESCRIPTION
Based on #219. Makes cfrg/draft-irtf-cfrg-opaque#238 possible.