### PR TITLE
Adding no_std support + alloc feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features ${{ matrix.backend_feature }}
+          args: --no-default-features --features std, ${{ matrix.backend_feature }}
 
   cross-test:
     name: Test on ${{ matrix.target }} (using cross)
@@ -60,7 +60,7 @@ jobs:
       - run: cargo install cross
       # Note: just use `cross` as you would `cargo`, but always
       # pass the `--target=${{ matrix.target }}` arg. (Yes, really).
-      - run: cross test --verbose --target=${{ matrix.target }} --no-default-features --features ${{ matrix.backend_feature }}
+      - run: cross test --verbose --target=${{ matrix.target }} --no-default-features --features std, ${{ matrix.backend_feature }}
 
 
   slow-hash-test:
@@ -76,7 +76,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: hecrj/setup-rust-action@v1
-      - run: cargo test --verbose --features slow-hash --no-default-features --features ${{ matrix.backend_feature }}
+      - run: cargo test --verbose --features slow-hash --no-default-features --features std, ${{ matrix.backend_feature }}
 
   serde-test:
     name: Test on ${{ matrix.target }} with serde support
@@ -91,8 +91,33 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: hecrj/setup-rust-action@v1
-      - run: cargo test --verbose --features serialize --no-default-features --features ${{ matrix.backend_feature }}
+      - run: cargo test --verbose --features serialize --no-default-features --features std, ${{ matrix.backend_feature }}
 
+  no-std:
+    name: no-std
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - stable
+          - 1.51.0
+        target:
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v2
+      - name: install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+      - run: rustup target add wasm32-unknown-unknown
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose --no-default-features --features alloc --target ${{ matrix.target }}
 
   simple-login-test:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ edition = "2018"
 readme = "README.md"
 
 [features]
-default = ["u64_backend", "serialize"]
+alloc = []
+std = []
+default = ["u64_backend", "serialize", "std"]
 slow-hash = ["argon2"]
 p256 = ["num-bigint", "num-integer", "num-traits", "once_cell", "p256_"]
 bench = []

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -3,6 +3,11 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
 use crate::{
     ciphersuite::CipherSuite,
     errors::{utils::check_slice_size, InternalPakeError, PakeError, ProtocolError},
@@ -11,13 +16,13 @@ use crate::{
     keypair::{KeyPair, PrivateKey, PublicKey},
     opaque::{bytestrings_from_identifiers, Identifiers},
 };
+use core::convert::TryFrom;
 use digest::Digest;
 use generic_array::{typenum::Unsigned, GenericArray};
 use generic_bytes::SizedBytes;
 use hkdf::Hkdf;
 use hmac::{Hmac, Mac, NewMac};
 use rand::{CryptoRng, RngCore};
-use std::convert::TryFrom;
 use zeroize::Zeroize;
 
 // Constant string used as salt for HKDF computation

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,14 +4,11 @@
 // LICENSE file in the root directory of this source tree.
 
 //! A list of error types which are produced during an execution of the protocol
-use std::convert::Infallible;
-use std::error::Error;
-use std::fmt::Debug;
-
-use displaydoc::Display;
+use core::convert::Infallible;
+use core::fmt::{Debug, Display};
 
 /// Represents an error in the manipulation of internal cryptographic data
-#[derive(Clone, Display, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum InternalPakeError<T = Infallible> {
     /// Custom [`SecretKey`](crate::keypair::SecretKey) error type
     Custom(T),
@@ -60,8 +57,8 @@ pub enum InternalPakeError<T = Infallible> {
     UnexpectedEnvelopeContentsError,
 }
 
-impl<T: Debug> Debug for InternalPakeError<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T: Debug + Display> Display for InternalPakeError<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Custom(custom) => f.debug_tuple("InvalidByteSequence").field(custom).finish(),
             Self::InvalidByteSequence => f.debug_tuple("InvalidByteSequence").finish(),
@@ -98,8 +95,6 @@ impl<T: Debug> Debug for InternalPakeError<T> {
     }
 }
 
-impl<T: Error> Error for InternalPakeError<T> {}
-
 impl InternalPakeError {
     /// Convert `InternalPakeError<Infallible>` into `InternalPakeError<T>
     pub fn into_custom<T>(self) -> InternalPakeError<T> {
@@ -135,7 +130,7 @@ impl InternalPakeError {
 }
 
 /// Represents an error in password checking
-#[derive(Clone, Display, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum PakeError<T = Infallible> {
     /** This error results from an internal error during PRF construction
 
@@ -156,8 +151,8 @@ pub enum PakeError<T = Infallible> {
     IdentityGroupElementError,
 }
 
-impl<T: Debug> Debug for PakeError<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T: Debug + Display> Display for PakeError<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::CryptoError(internal_pake_error) => f
                 .debug_tuple("CryptoError")
@@ -176,8 +171,6 @@ impl<T: Debug> Debug for PakeError<T> {
         }
     }
 }
-
-impl<T: Error> Error for PakeError<T> {}
 
 // This is meant to express future(ly) non-trivial ways of converting the
 // internal error into a PakeError
@@ -207,7 +200,7 @@ impl PakeError {
 }
 
 /// Represents an error in protocol handling
-#[derive(Clone, Display, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ProtocolError<T = Infallible> {
     /** This error results from an error during password verification
 
@@ -229,8 +222,8 @@ pub enum ProtocolError<T = Infallible> {
     ReflectedValueError,
 }
 
-impl<T: Debug> Debug for ProtocolError<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T: Debug + Display> Display for ProtocolError<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::VerificationError(pake_error) => f
                 .debug_tuple("VerificationError")
@@ -246,8 +239,6 @@ impl<T: Debug> Debug for ProtocolError<T> {
         }
     }
 }
-
-impl<T: Error> Error for ProtocolError<T> {}
 
 // This is meant to express future(ly) non-trivial ways of converting the
 // Pake error into a ProtocolError
@@ -268,8 +259,8 @@ impl<T> From<InternalPakeError<T>> for ProtocolError<T> {
 // See https://github.com/rust-lang/rust/issues/64715 and remove this when
 // merged, and https://github.com/dtolnay/thiserror/issues/62 for why this
 // comes up in our doc tests.
-impl<T> From<::std::convert::Infallible> for ProtocolError<T> {
-    fn from(_: ::std::convert::Infallible) -> Self {
+impl<T> From<::core::convert::Infallible> for ProtocolError<T> {
+    fn from(_: ::core::convert::Infallible) -> Self {
         unreachable!()
     }
 }

--- a/src/group/expand.rs
+++ b/src/group/expand.rs
@@ -3,6 +3,11 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
 use crate::errors::{InternalPakeError, ProtocolError};
 use crate::hash::Hash;
 use crate::serialization::i2osp;
@@ -66,6 +71,7 @@ pub fn expand_message_xmd<H: Hash>(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
     struct Params {
         msg: &'static str,

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -11,11 +11,16 @@ mod expand;
 pub(crate) mod p256;
 mod ristretto;
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
 use crate::errors::{InternalPakeError, ProtocolError};
 use crate::hash::Hash;
+use core::ops::Mul;
 use generic_array::{ArrayLength, GenericArray};
 use rand::{CryptoRng, RngCore};
-use std::ops::Mul;
 use zeroize::Zeroize;
 
 /// A prime-order subgroup of a base field (EC, prime-order field ...). This

--- a/src/group/p256.rs
+++ b/src/group/p256.rs
@@ -11,6 +11,7 @@
 use super::Group;
 use crate::errors::{InternalPakeError, ProtocolError};
 use crate::hash::Hash;
+use alloc::{string::ToString, vec::Vec};
 use generic_array::typenum::{U32, U33};
 use generic_array::{ArrayLength, GenericArray};
 use num_bigint::{BigInt, Sign};

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -6,6 +6,7 @@
 use super::Group;
 use crate::errors::{InternalPakeError, ProtocolError};
 use crate::hash::Hash;
+use core::convert::TryInto;
 use curve25519_dalek::{
     constants::RISTRETTO_BASEPOINT_POINT,
     ristretto::{CompressedRistretto, RistrettoPoint},
@@ -14,7 +15,6 @@ use curve25519_dalek::{
 };
 use generic_array::{typenum::U32, GenericArray};
 use rand::{CryptoRng, RngCore};
-use std::convert::TryInto;
 use subtle::ConstantTimeEq;
 
 /// The implementation of such a subgroup for Ristretto

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -5,10 +5,10 @@
 
 macro_rules! impl_debug_eq_hash_for {
     (struct $name:ident$(<$($gen:ident$(: $bound:tt)?),+$(,)?>)?, [$field1:ident$(, $field2:ident)*$(,)?]$(, )?$([$($type:ty),+$(,)?]$(,)?)?) => {
-        impl$(<$($gen$(: $bound)?),+>)? std::fmt::Debug for $name$(<$($gen),+>)?
-        $(where $($type: std::fmt::Debug,)+)?
+        impl$(<$($gen$(: $bound)?),+>)? core::fmt::Debug for $name$(<$($gen),+>)?
+        $(where $($type: core::fmt::Debug,)+)?
         {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 f.debug_struct("$name")
                 .field("$field1", &self.$field1)
                 $(.field("$field2", &self.$field2))*
@@ -29,20 +29,20 @@ macro_rules! impl_debug_eq_hash_for {
             }
         }
 
-        impl$(<$($gen$(: $bound)?),+>)? std::hash::Hash for $name$(<$($gen),+>)?
-        $(where $($type: std::hash::Hash,)+)?
+        impl$(<$($gen$(: $bound)?),+>)? core::hash::Hash for $name$(<$($gen),+>)?
+        $(where $($type: core::hash::Hash,)+)?
         {
-            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-                std::hash::Hash::hash(&self.$field1, state);
-                $(std::hash::Hash::hash(&self.$field2, state);)*
+            fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+                core::hash::Hash::hash(&self.$field1, state);
+                $(core::hash::Hash::hash(&self.$field2, state);)*
             }
         }
     };
     (tuple $name:ident$(<$($gen:ident$(: $bound:tt)?),+$(,)?>)?, [$field1:tt$(, $field2:tt)*$(,)?]$(, )?$([$($type:ty),+$(,)?]$(,)?)?) => {
-        impl$(<$($gen$(: $bound)?),+>)? std::fmt::Debug for $name$(<$($gen),+>)?
-        $(where $($type: std::fmt::Debug,)+)?
+        impl$(<$($gen$(: $bound)?),+>)? core::fmt::Debug for $name$(<$($gen),+>)?
+        $(where $($type: core::fmt::Debug,)+)?
         {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 f.debug_tuple("$name")
                 .field(&self.$field1)
                 $(.field(&self.$field2))*
@@ -63,12 +63,12 @@ macro_rules! impl_debug_eq_hash_for {
             }
         }
 
-        impl$(<$($gen$(: $bound)?),+>)? std::hash::Hash for $name$(<$($gen),+>)?
-        $(where $($type: std::hash::Hash,)+)?
+        impl$(<$($gen$(: $bound)?),+>)? core::hash::Hash for $name$(<$($gen),+>)?
+        $(where $($type: core::hash::Hash,)+)?
         {
-            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-                std::hash::Hash::hash(&self.$field1, state);
-                $(std::hash::Hash::hash(&self.$field2, state);)*
+            fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+                core::hash::Hash::hash(&self.$field1, state);
+                $(core::hash::Hash::hash(&self.$field2, state);)*
             }
         }
     };

--- a/src/key_exchange/traits.rs
+++ b/src/key_exchange/traits.rs
@@ -3,6 +3,11 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
 use crate::{
     ciphersuite::CipherSuite,
     errors::{PakeError, ProtocolError},

--- a/src/key_exchange/tripledh.rs
+++ b/src/key_exchange/tripledh.rs
@@ -4,6 +4,12 @@
 // LICENSE file in the root directory of this source tree.
 
 //! An implementation of the Triple Diffie-Hellman key exchange protocol
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
 use crate::{
     ciphersuite::CipherSuite,
     errors::{
@@ -18,6 +24,7 @@ use crate::{
     keypair::{KeyPair, PrivateKey, PublicKey, SecretKey, SizedBytesExt},
     serialization::serialize,
 };
+use core::convert::TryFrom;
 use digest::{Digest, FixedOutput};
 use generic_array::{
     typenum::{Unsigned, U32},
@@ -27,7 +34,6 @@ use generic_bytes::SizedBytes;
 use hkdf::Hkdf;
 use hmac::{Hmac, Mac, NewMac};
 use rand::{CryptoRng, RngCore};
-use std::convert::TryFrom;
 use zeroize::Zeroize;
 
 pub(crate) type NonceLen = U32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -803,15 +803,33 @@
 //!
 //! - The `bench` feature is used only for running performance benchmarks for this implementation.
 //!
+//! - The `alloc` feature can be enabled as an alternative to `std` (which is enabled by default). This
+//! can be used for supporting WebAssembly targets.
+//!
 
 #![cfg_attr(not(feature = "bench"), deny(missing_docs))]
 #![deny(unsafe_code)]
+#![no_std]
 
 #[cfg(not(any(feature = "u64_backend", feature = "u32_backend",)))]
 compile_error!(
     "no dalek arithmetic backend cargo feature enabled! \
      please enable one of: u64_backend, u32_backend"
 );
+
+#[cfg(not(any(feature = "std", feature = "alloc")))]
+compile_error!("Either feature \"std\" or \"alloc\" must be enabled for this crate.");
+
+#[cfg(all(feature = "alloc", feature = "std"))]
+compile_error!("This crate does not support features \"alloc\" and \"std\" simultaneously.");
+
+#[cfg(feature = "alloc")]
+#[macro_use]
+extern crate alloc;
+
+#[cfg(any(feature = "std", test))]
+#[macro_use]
+extern crate std;
 
 // Error types
 pub mod errors;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -5,6 +5,11 @@
 
 //! Contains the messages used for OPAQUE
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
 use crate::{
     ciphersuite::CipherSuite,
     envelope::Envelope,

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -5,6 +5,11 @@
 
 //! Provides the main OPAQUE API
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
 use crate::{
     ciphersuite::CipherSuite,
     envelope::Envelope,
@@ -19,12 +24,12 @@ use crate::{
     CredentialFinalization, CredentialRequest, CredentialResponse, RegistrationRequest,
     RegistrationResponse, RegistrationUpload,
 };
+use core::marker::PhantomData;
 use digest::Digest;
 use generic_array::{typenum::Unsigned, GenericArray};
 use generic_bytes::SizedBytes;
 use hkdf::Hkdf;
 use rand::{CryptoRng, RngCore};
-use std::marker::PhantomData;
 use zeroize::Zeroize;
 
 const STR_CREDENTIAL_RESPONSE_PAD: &[u8] = b"CredentialResponsePad";

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -3,6 +3,11 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
 use crate::{errors::ProtocolError, group::Group, hash::Hash, serialization::serialize};
 use digest::Digest;
 use generic_array::GenericArray;

--- a/src/serialization/mod.rs
+++ b/src/serialization/mod.rs
@@ -3,11 +3,16 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
 use crate::errors::PakeError;
 
 // Corresponds to the I2OSP() function from RFC8017
 pub(crate) fn i2osp(input: usize, length: usize) -> Result<Vec<u8>, PakeError> {
-    let sizeof_usize = std::mem::size_of::<usize>();
+    let sizeof_usize = core::mem::size_of::<usize>();
 
     // Check if input >= 256^length
     if (sizeof_usize as u32 - input.leading_zeros() / 8) > length as u32 {
@@ -28,12 +33,12 @@ pub(crate) fn i2osp(input: usize, length: usize) -> Result<Vec<u8>, PakeError> {
 
 // Corresponds to the OS2IP() function from RFC8017
 pub(crate) fn os2ip(input: &[u8]) -> Result<usize, PakeError> {
-    if input.len() > std::mem::size_of::<usize>() {
+    if input.len() > core::mem::size_of::<usize>() {
         return Err(PakeError::SerializationError);
     }
 
-    let mut output_array = [0u8; std::mem::size_of::<usize>()];
-    output_array[std::mem::size_of::<usize>() - input.len()..].copy_from_slice(input);
+    let mut output_array = [0u8; core::mem::size_of::<usize>()];
+    output_array[core::mem::size_of::<usize>() - input.len()..].copy_from_slice(input);
     Ok(usize::from_be_bytes(output_array))
 }
 
@@ -45,7 +50,7 @@ pub(crate) fn serialize(input: &[u8], max_bytes: usize) -> Result<Vec<u8>, PakeE
 // Tokenizes an input of the format I2OSP(len(input), max_bytes) || input, outputting
 // (input, remainder)
 pub(crate) fn tokenize(input: &[u8], size_bytes: usize) -> Result<(Vec<u8>, Vec<u8>), PakeError> {
-    if size_bytes > std::mem::size_of::<usize>() || input.len() < size_bytes {
+    if size_bytes > core::mem::size_of::<usize>() || input.len() < size_bytes {
         return Err(PakeError::SerializationError);
     }
 
@@ -89,17 +94,17 @@ macro_rules! impl_serialize_and_deserialize_for {
                         .map_err(serde::de::Error::custom)
                 } else {
                     struct ByteVisitor<CS: CipherSuite> {
-                        marker: std::marker::PhantomData<CS>,
+                        marker: core::marker::PhantomData<CS>,
                     }
                     impl<'de, CS: CipherSuite> serde::de::Visitor<'de> for ByteVisitor<CS> {
                         type Value = $t<CS>;
                         fn expecting(
                             &self,
-                            formatter: &mut std::fmt::Formatter,
-                        ) -> std::fmt::Result {
-                            formatter.write_str(std::concat!(
+                            formatter: &mut core::fmt::Formatter,
+                        ) -> core::fmt::Result {
+                            formatter.write_str(core::concat!(
                                 "the byte representation of a ",
-                                std::stringify!($t)
+                                core::stringify!($t)
                             ))
                         }
 
@@ -110,16 +115,16 @@ macro_rules! impl_serialize_and_deserialize_for {
                             $t::<CS>::deserialize(value).map_err(|_| {
                                 serde::de::Error::invalid_value(
                                     serde::de::Unexpected::Bytes(value),
-                                    &std::concat!(
+                                    &core::concat!(
                                         "invalid byte sequence for ",
-                                        std::stringify!($t)
+                                        core::stringify!($t)
                                     ),
                                 )
                             })
                         }
                     }
                     deserializer.deserialize_bytes(ByteVisitor::<CS> {
-                        marker: std::marker::PhantomData,
+                        marker: core::marker::PhantomData,
                     })
                 }
             }

--- a/src/serialization/tests.rs
+++ b/src/serialization/tests.rs
@@ -3,6 +3,11 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
 use crate::{
     ciphersuite::CipherSuite,
     envelope::{Envelope, InnerEnvelopeMode},
@@ -351,7 +356,7 @@ proptest! {
 
 #[test]
 fn test_i2osp_os2ip(bytes in vec(any::<u8>(), 0..std::mem::size_of::<usize>())) {
-    assert_eq!(i2osp(os2ip(&bytes)?, bytes.len())?, bytes);
+    assert_eq!(i2osp(os2ip(&bytes).unwrap(), bytes.len()).unwrap(), bytes);
 }
 
 #[test]

--- a/src/slow_hash.rs
+++ b/src/slow_hash.rs
@@ -5,6 +5,11 @@
 
 //! Trait specifying a slow hashing function
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
 use crate::{errors::InternalPakeError, hash::Hash};
 use digest::Digest;
 #[cfg(feature = "slow-hash")]

--- a/src/tests/full_test.rs
+++ b/src/tests/full_test.rs
@@ -5,6 +5,17 @@
 
 #![allow(unsafe_code)]
 
+#[cfg(feature = "alloc")]
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+#[cfg(feature = "std")]
+use std::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
 use crate::{
     ciphersuite::CipherSuite,
     errors::*,

--- a/src/tests/mock_rng.rs
+++ b/src/tests/mock_rng.rs
@@ -3,6 +3,11 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
 use rand::{CryptoRng, Error, RngCore};
 use std::cmp::min;
 

--- a/src/tests/opaque_test_vectors.rs
+++ b/src/tests/opaque_test_vectors.rs
@@ -3,6 +3,17 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#[cfg(feature = "alloc")]
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+#[cfg(feature = "std")]
+use std::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
 use crate::{
     ciphersuite::CipherSuite, errors::*, key_exchange::tripledh::TripleDH, keypair::PrivateKey,
     opaque::*, slow_hash::NoOpHash, tests::mock_rng::CycleRng, *,

--- a/src/tests/voprf_test_vectors.rs
+++ b/src/tests/voprf_test_vectors.rs
@@ -3,6 +3,11 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+#[cfg(feature = "alloc")]
+use alloc::{string::ToString, vec::Vec};
+#[cfg(feature = "std")]
+use std::{string::ToString, vec::Vec};
+
 use crate::group::Group;
 use crate::hash::Hash;
 use crate::tests::mock_rng::CycleRng;


### PR DESCRIPTION
Adds support for no_std for WebAssembly targets. This also introduces the `alloc` feature, not enabled by default.