### PR TITLE
Fix `no_std` support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,15 +145,20 @@ jobs:
         target:
           # for wasm
           - wasm32-unknown-unknown
+          # for any no_std target
+          - thumbv6m-none-eabi
         backend_feature:
           - u64_backend
           - u32_backend
           - p256,u64_backend
+        frontend_feature:
+          - slow-hash
+          - serialize
     steps:
       - uses: actions/checkout@v2
       - uses: hecrj/setup-rust-action@v1
       - run: rustup target add ${{ matrix.target }}
-      - run: cargo build --verbose --target=${{ matrix.target }} --no-default-features --features ${{ matrix.backend_feature }}
+      - run: cargo build --verbose --target=${{ matrix.target }} --no-default-features --features ${{ matrix.frontend_feature }} --features ${{ matrix.backend_feature }}
 
   benches:
     name: cargo bench compilation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ authors = ["Kevin Lewi <klewi@fb.com>", "François Garillot <fga@fb.com>"]
 license = "MIT"
 edition = "2018"
 readme = "README.md"
+resolver = "2"
 
 [features]
 default = ["u64_backend", "serialize"]
@@ -17,31 +18,32 @@ p256 = ["num-bigint", "num-integer", "num-traits", "once_cell", "p256_"]
 bench = []
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
-std = ["curve25519-dalek/std"]
+std = ["curve25519-dalek/std", "getrandom", "rand/std", "rand/std_rng", "num-bigint/std", "num-integer/std", "num-traits/std"]
 serialize = ["serde", "base64", "generic-array/serde", "curve25519-dalek/serde"]
 
 [dependencies]
-argon2 = { version = "0.2", optional = true }
-base64 = { version = "0.13", optional = true }
+argon2 = { version = "0.2", default-features = false, optional = true }
+base64 = { version = "0.13", default-features = false, features = ["alloc"], optional = true }
 constant_time_eq = "0.1"
 curve25519-dalek = { version = "3", default-features = false }
 digest = "0.9"
-displaydoc = "0.2"
+displaydoc = { version = "0.2", default-features = false }
 generic-array = "0.14"
-generic-bytes = { version = "0.1" }
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.2", optional = true }
 hkdf = "0.11"
 hmac = "0.11"
-num-bigint = { version = "0.4", optional = true }
-num-integer = { version = "0.1", optional = true }
-num-traits = { version = "0.2", optional = true }
-once_cell = { version = "1", optional = true }
-p256_ = { package = "p256", version = "0.9", optional = true }
+num-bigint = { version = "0.4", default-features = false, optional = true }
+num-integer = { version = "0.1", default-features = false, optional = true }
+num-traits = { version = "0.2", default-features = false, optional = true }
+once_cell = { version = "1", default-features = false, optional = true }
+p256_ = { package = "p256", version = "0.9", default-features = false, features = ["arithmetic", "zeroize"], optional = true }
 rand = { version = "0.8", default-features = false }
-serde = { version = "1", features = ["derive"], optional = true }
+serde = { version = "1", default-features = false, features = ["alloc", "derive"], optional = true }
 subtle = { version = "2.3", default-features = false }
-thiserror = "1"
 zeroize = { version = "1", features = ["zeroize_derive"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"], optional = true }
 
 [dev-dependencies]
 base64 = "0.13"
@@ -50,6 +52,7 @@ chacha20poly1305 = "0.8"
 criterion = "0.3"
 hex = "0.4"
 lazy_static = "1"
+opaque-ke = { path = "", default-features = false, features = ["std"] }
 serde_json = "1"
 sha2 = "0.9"
 proptest = "1"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -296,24 +296,6 @@ impl ProtocolError {
     }
 }
 
-impl<T> From<generic_bytes::TryFromSizedBytesError> for InternalPakeError<T> {
-    fn from(_: generic_bytes::TryFromSizedBytesError) -> Self {
-        InternalPakeError::InvalidByteSequence
-    }
-}
-
-impl<T> From<generic_bytes::TryFromSizedBytesError> for PakeError<T> {
-    fn from(e: generic_bytes::TryFromSizedBytesError) -> Self {
-        PakeError::CryptoError(e.into())
-    }
-}
-
-impl<T> From<generic_bytes::TryFromSizedBytesError> for ProtocolError<T> {
-    fn from(e: generic_bytes::TryFromSizedBytesError) -> Self {
-        PakeError::CryptoError(e.into()).into()
-    }
-}
-
 pub(crate) mod utils {
     use super::*;
 

--- a/src/group/expand.rs
+++ b/src/group/expand.rs
@@ -31,8 +31,8 @@ pub fn expand_message_xmd<H: Hash>(
     dst: &[u8],
     len_in_bytes: usize,
 ) -> Result<Vec<u8>, ProtocolError> {
-    let b_in_bytes = <H as Digest>::OutputSize::to_usize();
-    let r_in_bytes = <H as BlockInput>::BlockSize::to_usize();
+    let b_in_bytes = <H as Digest>::OutputSize::USIZE;
+    let r_in_bytes = <H as BlockInput>::BlockSize::USIZE;
 
     let ell = div_ceil(len_in_bytes, b_in_bytes);
     if ell > 255 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -748,7 +748,6 @@
 //! ```
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use generic_array::{GenericArray, typenum::U32};
-//! # use generic_bytes::SizedBytes;
 //! # use opaque_ke::{CipherSuite, errors::{InternalPakeError}, keypair::{KeyPair, PrivateKey, PublicKey, SecretKey}, ServerSetup};
 //! # use rand::rngs::OsRng;
 //! # use zeroize::Zeroize;
@@ -781,8 +780,7 @@
 //!     fn public_key(
 //!         &self
 //!     ) -> Result<PublicKey<RistrettoPoint>, InternalPakeError<Self::Error>> {
-//!         let pk = YourRemoteKey::public_key(self).map_err(InternalPakeError::Custom)?;
-//!         PublicKey::from_arr(&pk).map_err(InternalPakeError::from)
+//!         YourRemoteKey::public_key(self).map(PublicKey::from_arr).map_err(InternalPakeError::Custom)
 //!     }
 //!
 //!     fn serialize(&self) -> Vec<u8> {
@@ -796,7 +794,7 @@
 //!     }
 //! }
 //!
-//! # let remote_key = YourRemoteKey(PrivateKey::from_arr(&GenericArray::default()).unwrap());
+//! # let remote_key = YourRemoteKey(PrivateKey::from_arr(GenericArray::default()));
 //! let keypair = KeyPair::from_private_key(remote_key).unwrap();
 //! let server_setup = ServerSetup::<Default, YourRemoteKey>::new_with_key(&mut OsRng, keypair);
 //! ```

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -14,13 +14,12 @@ use crate::{
     },
     group::Group,
     key_exchange::traits::{FromBytes, KeyExchange, ToBytes},
-    keypair::{KeyPair, PublicKey, SecretKey, SizedBytesExt},
+    keypair::{KeyPair, PublicKey, SecretKey},
     opaque::ServerSetup,
 };
 use alloc::vec::Vec;
 use digest::Digest;
 use generic_array::{typenum::Unsigned, GenericArray};
-use generic_bytes::SizedBytes;
 use rand::{CryptoRng, RngCore};
 
 // Messages
@@ -57,7 +56,7 @@ impl<CS: CipherSuite> RegistrationRequest<CS> {
 
     /// Deserialization from bytes
     pub fn deserialize(input: &[u8]) -> Result<Self, ProtocolError> {
-        let elem_len = <CS::OprfGroup as Group>::ElemLen::to_usize();
+        let elem_len = <CS::OprfGroup as Group>::ElemLen::USIZE;
         let checked_slice = check_slice_size(input, elem_len, "first_message_bytes")?;
         // Check that the message is actually containing an element of the
         // correct subgroup
@@ -107,8 +106,8 @@ impl<CS: CipherSuite> RegistrationResponse<CS> {
 
     /// Deserialization from bytes
     pub fn deserialize(input: &[u8]) -> Result<Self, ProtocolError> {
-        let elem_len = <CS::OprfGroup as Group>::ElemLen::to_usize();
-        let key_len = <PublicKey<CS::KeGroup> as SizedBytes>::Len::to_usize();
+        let elem_len = <CS::OprfGroup as Group>::ElemLen::USIZE;
+        let key_len = <CS::KeGroup as Group>::ElemLen::USIZE;
         let checked_slice =
             check_slice_size(input, elem_len + key_len, "registration_response_bytes")?;
 
@@ -177,8 +176,8 @@ impl<CS: CipherSuite> RegistrationUpload<CS> {
 
     /// Deserialization from bytes
     pub fn deserialize(input: &[u8]) -> Result<Self, ProtocolError> {
-        let key_len = <PublicKey<CS::KeGroup> as SizedBytes>::Len::to_usize();
-        let hash_len = <CS::Hash as Digest>::OutputSize::to_usize();
+        let key_len = <CS::KeGroup as Group>::ElemLen::USIZE;
+        let hash_len = <CS::Hash as Digest>::OutputSize::USIZE;
         let checked_slice =
             check_slice_size_atleast(input, key_len + hash_len, "registration_upload_bytes")?;
         let envelope = Envelope::<CS>::deserialize(&checked_slice[key_len + hash_len..])?;
@@ -198,7 +197,7 @@ impl<CS: CipherSuite> RegistrationUpload<CS> {
         rng: &mut R,
         server_setup: &ServerSetup<CS, S>,
     ) -> Self {
-        let mut masking_key = alloc::vec![0u8; <CS::Hash as Digest>::OutputSize::to_usize()];
+        let mut masking_key = alloc::vec![0u8; <CS::Hash as Digest>::OutputSize::USIZE];
         rng.fill_bytes(&mut masking_key);
 
         Self {
@@ -245,7 +244,7 @@ impl<CS: CipherSuite> CredentialRequest<CS> {
 
     /// Deserialization from bytes
     pub fn deserialize(input: &[u8]) -> Result<Self, ProtocolError> {
-        let elem_len = <CS::OprfGroup as Group>::ElemLen::to_usize();
+        let elem_len = <CS::OprfGroup as Group>::ElemLen::USIZE;
 
         let checked_slice = check_slice_size_atleast(input, elem_len, "login_first_message_bytes")?;
 
@@ -327,8 +326,8 @@ impl<CS: CipherSuite> CredentialResponse<CS> {
 
     /// Deserialization from bytes
     pub fn deserialize(input: &[u8]) -> Result<Self, ProtocolError> {
-        let elem_len = <CS::OprfGroup as Group>::ElemLen::to_usize();
-        let key_len = <PublicKey<CS::KeGroup> as SizedBytes>::Len::to_usize();
+        let elem_len = <CS::OprfGroup as Group>::ElemLen::USIZE;
+        let key_len = <CS::KeGroup as Group>::ElemLen::USIZE;
         let nonce_len: usize = 32;
         let envelope_len = Envelope::<CS>::len();
         let masked_response_len = key_len + envelope_len;

--- a/src/slow_hash.rs
+++ b/src/slow_hash.rs
@@ -37,7 +37,7 @@ impl<D: Hash> SlowHash<D> for argon2::Argon2<'_> {
         input: GenericArray<u8, <D as Digest>::OutputSize>,
     ) -> Result<Vec<u8>, InternalPakeError> {
         let params = argon2::Argon2::default();
-        let mut output = alloc::vec![0u8; <D as Digest>::OutputSize::to_usize()];
+        let mut output = alloc::vec![0u8; <D as Digest>::OutputSize::USIZE];
         params
             .hash_password_into(
                 argon2::Algorithm::Argon2id,

--- a/src/tests/full_test.rs
+++ b/src/tests/full_test.rs
@@ -14,7 +14,6 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::slice::from_raw_parts;
 use curve25519_dalek::{ristretto::RistrettoPoint, traits::Identity};
-use generic_bytes::SizedBytes;
 use rand::rngs::OsRng;
 use serde_json::Value;
 use zeroize::Zeroize;
@@ -149,7 +148,6 @@ fn populate_test_vectors(values: &Value) -> TestVectorParameters {
     }
 }
 
-#[cfg(feature = "std")]
 fn stringify_test_vectors(p: &TestVectorParameters) -> alloc::string::String {
     let mut s = alloc::string::String::new();
     s.push_str("{\n");
@@ -273,7 +271,6 @@ fn stringify_test_vectors(p: &TestVectorParameters) -> alloc::string::String {
     s
 }
 
-#[cfg(feature = "std")]
 fn generate_parameters<CS: CipherSuite>() -> TestVectorParameters {
     use crate::{group::Group, key_exchange::tripledh::NonceLen, keypair::KeyPair};
     use generic_array::typenum::Unsigned;
@@ -298,9 +295,9 @@ fn generate_parameters<CS: CipherSuite>() -> TestVectorParameters {
     rng.fill_bytes(&mut masking_nonce);
     let mut envelope_nonce = [0u8; 32];
     rng.fill_bytes(&mut envelope_nonce);
-    let mut client_nonce = vec![0u8; NonceLen::to_usize()];
+    let mut client_nonce = vec![0u8; NonceLen::USIZE];
     rng.fill_bytes(&mut client_nonce);
-    let mut server_nonce = vec![0u8; NonceLen::to_usize()];
+    let mut server_nonce = vec![0u8; NonceLen::USIZE];
     rng.fill_bytes(&mut server_nonce);
 
     let fake_sk: Vec<u8> = fake_kp.private().to_vec();
@@ -448,7 +445,6 @@ fn generate_parameters<CS: CipherSuite>() -> TestVectorParameters {
     }
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn generate_test_vectors() {
     let parameters = generate_parameters::<RistrettoSha5123dhNoSlowHash>();

--- a/src/tests/opaque_test_vectors.rs
+++ b/src/tests/opaque_test_vectors.rs
@@ -4,15 +4,14 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{
-    ciphersuite::CipherSuite, errors::*, key_exchange::tripledh::TripleDH, keypair::PrivateKey,
-    opaque::*, slow_hash::NoOpHash, tests::mock_rng::CycleRng, *,
+    ciphersuite::CipherSuite, errors::*, group::Group, key_exchange::tripledh::TripleDH, opaque::*,
+    slow_hash::NoOpHash, tests::mock_rng::CycleRng, *,
 };
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use alloc::{format, vec};
 use curve25519_dalek::ristretto::RistrettoPoint;
 use generic_array::typenum::Unsigned;
-use generic_bytes::SizedBytes;
 use serde_json::Value;
 
 // Tests
@@ -755,7 +754,7 @@ fn populate_test_vectors<CS: CipherSuite>(values: &Value) -> TestVectorParameter
         dummy_private_key: parse_default!(
             values,
             "client_private_key",
-            vec![0u8; <PrivateKey<CS::OprfGroup> as SizedBytes>::Len::to_usize()]
+            vec![0u8; <CS::OprfGroup as Group>::ScalarLen::USIZE]
         ),
         dummy_masking_key: parse_default!(values, "masking_key", vec![0u8; 64]),
         context: parse!(values, "Context"),


### PR DESCRIPTION
Apparently rust and cargo can't check for dependency support for `no_std`, one easy way to test it is to use the `thumbv6m-none-eabi` target, which I included now in CI.

This helped narrow down what dependencies were actually broken for `no_std` support.
generic-bytes had to be removed, because it doesn't have `no_std` support. This wasn't an issue per se, but some of it's functionality had to be replaced with custom functions, back-porting this to opaque-ke 1.0 would be a breaking change I have no clue exactly how to solve.

A common bug, see https://github.com/rust-lang/cargo/issues/4866, unified std features from a dev-dependency on normal builds, this was easily rectified by switching to the new feature resolver version.
The new resolver has an MSRV of 1.51, which works fine for this version, but not if we want to backport it to opaque-ke 1.0, which will have to be fixed differently. This isn't an issue that will affect consumers of this library, it's only an issue for us during testing.

For WASM, I think there was some misconception around the `getrandom` crate and `no_std` support. If you wanna use `no_std` with WASM, you can't use wasm-bindgen, which I believe requires std support. So to support for `no_std`, a user will have to provide their own implementation to be passed into functions.

I also added testing to automatically activate the "std" crate feature.

Additionally any calls to `typenum::Unsigned::to_usize()` were replaced with `typenum::Unsigned::USIZE`.