### PR TITLE
Simplifying error handling

### DIFF
--- a/src/group/expand.rs
+++ b/src/group/expand.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use crate::errors::{InternalPakeError, ProtocolError};
+use crate::errors::{InternalError, ProtocolError};
 use crate::hash::Hash;
 use crate::serialization::i2osp;
 use alloc::vec::Vec;
@@ -16,9 +16,9 @@ fn div_ceil(x: usize, y: usize) -> usize {
     x / y + additive
 }
 
-fn xor(x: &[u8], y: &[u8]) -> Result<Vec<u8>, InternalPakeError> {
+fn xor(x: &[u8], y: &[u8]) -> Result<Vec<u8>, InternalError> {
     if x.len() != y.len() {
-        return Err(InternalPakeError::HashToCurveError);
+        return Err(InternalError::HashToCurveError);
     }
 
     Ok(x.iter().zip(y).map(|(&x1, &x2)| x1 ^ x2).collect())
@@ -36,7 +36,7 @@ pub fn expand_message_xmd<H: Hash>(
 
     let ell = div_ceil(len_in_bytes, b_in_bytes);
     if ell > 255 {
-        return Err(InternalPakeError::HashToCurveError.into());
+        return Err(InternalError::HashToCurveError.into());
     }
     let dst_prime = [dst, &i2osp(dst.len(), 1)?].concat();
     let z_pad = i2osp(0, r_in_bytes)?;

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod p256;
 mod ristretto;
 mod x25519;
 
-use crate::errors::{InternalPakeError, ProtocolError};
+use crate::errors::{InternalError, ProtocolError};
 use crate::hash::Hash;
 use core::ops::Mul;
 use generic_array::{ArrayLength, GenericArray};
@@ -47,7 +47,7 @@ pub trait Group: Copy + Sized + for<'a> Mul<&'a <Self as Group>::Scalar, Output 
     /// Return a scalar from its fixed-length bytes representation
     fn from_scalar_slice(
         scalar_bits: &GenericArray<u8, Self::ScalarLen>,
-    ) -> Result<Self::Scalar, InternalPakeError>;
+    ) -> Result<Self::Scalar, InternalError>;
     /// picks a scalar at random
     fn random_nonzero_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar;
     /// Serializes a scalar to bytes
@@ -60,7 +60,7 @@ pub trait Group: Copy + Sized + for<'a> Mul<&'a <Self as Group>::Scalar, Output 
     /// Return an element from its fixed-length bytes representation
     fn from_element_slice(
         element_bits: &GenericArray<u8, Self::ElemLen>,
-    ) -> Result<Self, InternalPakeError>;
+    ) -> Result<Self, InternalError>;
     /// Serializes the `self` group element
     fn to_arr(&self) -> GenericArray<u8, Self::ElemLen>;
 

--- a/src/group/p256.rs
+++ b/src/group/p256.rs
@@ -9,7 +9,7 @@
 )]
 
 use super::Group;
-use crate::errors::{InternalPakeError, ProtocolError};
+use crate::errors::{InternalError, ProtocolError};
 use crate::hash::Hash;
 use core::ops::{Add, Div, Mul, Neg, Sub};
 use core::str::FromStr;
@@ -71,12 +71,12 @@ impl Group for ProjectivePoint {
         let p0 = AffinePoint::from_encoded_point(&EncodedPoint::from_affine_coordinates(
             &q0x, &q0y, false,
         ))
-        .ok_or(InternalPakeError::PointError)?
+        .ok_or(InternalError::PointError)?
         .to_curve();
         let p1 = AffinePoint::from_encoded_point(&EncodedPoint::from_affine_coordinates(
             &q1x, &q1y, false,
         ))
-        .ok_or(InternalPakeError::PointError)?;
+        .ok_or(InternalError::PointError)?;
 
         Ok(p0 + p1)
     }
@@ -113,7 +113,7 @@ impl Group for ProjectivePoint {
 
     fn from_scalar_slice(
         scalar_bits: &GenericArray<u8, Self::ScalarLen>,
-    ) -> Result<Self::Scalar, InternalPakeError> {
+    ) -> Result<Self::Scalar, InternalError> {
         Ok(Self::Scalar::from_bytes_reduced(scalar_bits))
     }
 
@@ -131,8 +131,8 @@ impl Group for ProjectivePoint {
 
     fn from_element_slice(
         element_bits: &GenericArray<u8, Self::ElemLen>,
-    ) -> Result<Self, InternalPakeError> {
-        Option::from(Self::from_bytes(element_bits)).ok_or(InternalPakeError::PointError)
+    ) -> Result<Self, InternalError> {
+        Option::from(Self::from_bytes(element_bits)).ok_or(InternalError::PointError)
     }
 
     fn to_arr(&self) -> GenericArray<u8, Self::ElemLen> {

--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::Group;
-use crate::errors::{InternalPakeError, ProtocolError};
+use crate::errors::{InternalError, ProtocolError};
 use crate::hash::Hash;
 use core::convert::TryInto;
 use curve25519_dalek::{
@@ -30,7 +30,7 @@ impl Group for RistrettoPoint {
             uniform_bytes
                 .as_slice()
                 .try_into()
-                .map_err(|_| InternalPakeError::HashToCurveError)?,
+                .map_err(|_| InternalError::HashToCurveError)?,
         ))
     }
 
@@ -43,7 +43,7 @@ impl Group for RistrettoPoint {
             uniform_bytes
                 .as_slice()
                 .try_into()
-                .map_err(|_| InternalPakeError::HashToCurveError)?,
+                .map_err(|_| InternalError::HashToCurveError)?,
         ))
     }
 
@@ -51,7 +51,7 @@ impl Group for RistrettoPoint {
     type ScalarLen = U32;
     fn from_scalar_slice(
         scalar_bits: &GenericArray<u8, Self::ScalarLen>,
-    ) -> Result<Self::Scalar, InternalPakeError> {
+    ) -> Result<Self::Scalar, InternalError> {
         Ok(Scalar::from_bytes_mod_order(*scalar_bits.as_ref()))
     }
     fn random_nonzero_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {
@@ -89,10 +89,10 @@ impl Group for RistrettoPoint {
     type ElemLen = U32;
     fn from_element_slice(
         element_bits: &GenericArray<u8, Self::ElemLen>,
-    ) -> Result<Self, InternalPakeError> {
+    ) -> Result<Self, InternalError> {
         CompressedRistretto::from_slice(element_bits)
             .decompress()
-            .ok_or(InternalPakeError::PointError)
+            .ok_or(InternalError::PointError)
     }
     // serialization of a group element
     fn to_arr(&self) -> GenericArray<u8, Self::ElemLen> {

--- a/src/group/x25519.rs
+++ b/src/group/x25519.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::Group;
-use crate::errors::{InternalPakeError, ProtocolError};
+use crate::errors::{InternalError, ProtocolError};
 use crate::hash::Hash;
 use curve25519_dalek::{constants::X25519_BASEPOINT, montgomery::MontgomeryPoint, scalar::Scalar};
 use generic_array::{typenum::U32, GenericArray};
@@ -26,7 +26,7 @@ impl Group for MontgomeryPoint {
     type ScalarLen = U32;
     fn from_scalar_slice(
         scalar_bits: &GenericArray<u8, Self::ScalarLen>,
-    ) -> Result<Self::Scalar, InternalPakeError> {
+    ) -> Result<Self::Scalar, InternalError> {
         Ok(Scalar::from_bytes_mod_order(*scalar_bits.as_ref()))
     }
     fn random_nonzero_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {
@@ -64,7 +64,7 @@ impl Group for MontgomeryPoint {
     type ElemLen = U32;
     fn from_element_slice(
         element_bits: &GenericArray<u8, Self::ElemLen>,
-    ) -> Result<Self, InternalPakeError> {
+    ) -> Result<Self, InternalError> {
         Ok(Self(*element_bits.as_ref()))
     }
     // serialization of a group element
@@ -93,8 +93,8 @@ impl Group for MontgomeryPoint {
 #[test]
 fn test() -> Result<(), ProtocolError> {
     use crate::{
-        errors::PakeError, key_exchange::tripledh::TripleDH, slow_hash::NoOpHash, CipherSuite,
-        ClientLogin, ClientLoginFinishParameters, ClientLoginFinishResult, ClientLoginStartResult,
+        key_exchange::tripledh::TripleDH, slow_hash::NoOpHash, CipherSuite, ClientLogin,
+        ClientLoginFinishParameters, ClientLoginFinishResult, ClientLoginStartResult,
         ClientRegistration, ClientRegistrationFinishParameters, ClientRegistrationFinishResult,
         ClientRegistrationStartResult, ServerLogin, ServerLoginStartParameters,
         ServerLoginStartResult, ServerRegistration, ServerSetup,
@@ -173,9 +173,7 @@ fn test() -> Result<(), ProtocolError> {
 
     assert!(matches!(
         client.finish(message, ClientLoginFinishParameters::Default),
-        Err(ProtocolError::VerificationError(
-            PakeError::InvalidLoginError
-        ))
+        Err(ProtocolError::InvalidLoginError)
     ));
 
     Ok(())

--- a/src/key_exchange/traits.rs
+++ b/src/key_exchange/traits.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     ciphersuite::CipherSuite,
-    errors::{PakeError, ProtocolError},
+    errors::ProtocolError,
     group::Group,
     hash::Hash,
     keypair::{PrivateKey, PublicKey, SecretKey},
@@ -83,7 +83,7 @@ pub trait KeyExchange<D: Hash, G: Group> {
 }
 
 pub trait FromBytes: Sized {
-    fn from_bytes<CS: CipherSuite>(input: &[u8]) -> Result<Self, PakeError>;
+    fn from_bytes<CS: CipherSuite>(input: &[u8]) -> Result<Self, ProtocolError>;
 }
 
 pub trait ToBytes {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -748,7 +748,7 @@
 //! ```
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use generic_array::{GenericArray, typenum::U32};
-//! # use opaque_ke::{CipherSuite, errors::{InternalPakeError}, keypair::{KeyPair, PrivateKey, PublicKey, SecretKey}, ServerSetup};
+//! # use opaque_ke::{CipherSuite, errors::{InternalError}, keypair::{KeyPair, PrivateKey, PublicKey, SecretKey}, ServerSetup};
 //! # use rand::rngs::OsRng;
 //! # use zeroize::Zeroize;
 //! # struct Default;
@@ -773,14 +773,14 @@
 //!     fn diffie_hellman(
 //!         &self,
 //!         pk: PublicKey<RistrettoPoint>,
-//!     ) -> Result<Vec<u8>, InternalPakeError<Self::Error>> {
-//!         YourRemoteKey::diffie_hellman(self, &pk.to_arr()).map_err(InternalPakeError::Custom)
+//!     ) -> Result<Vec<u8>, InternalError<Self::Error>> {
+//!         YourRemoteKey::diffie_hellman(self, &pk.to_arr()).map_err(InternalError::Custom)
 //!     }
 //!
 //!     fn public_key(
 //!         &self
-//!     ) -> Result<PublicKey<RistrettoPoint>, InternalPakeError<Self::Error>> {
-//!         YourRemoteKey::public_key(self).map(PublicKey::from_arr).map_err(InternalPakeError::Custom)
+//!     ) -> Result<PublicKey<RistrettoPoint>, InternalError<Self::Error>> {
+//!         YourRemoteKey::public_key(self).map(PublicKey::from_arr).map_err(InternalError::Custom)
 //!     }
 //!
 //!     fn serialize(&self) -> Vec<u8> {
@@ -788,7 +788,7 @@
 //!         todo!()
 //!     }
 //!
-//!     fn deserialize(input: &[u8]) -> Result<Self, InternalPakeError<Self::Error>> {
+//!     fn deserialize(input: &[u8]) -> Result<Self, InternalError<Self::Error>> {
 //!         // if you use serde and the "serialize" crate feature, you won't need this
 //!         todo!()
 //!     }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -10,7 +10,7 @@ use crate::{
     envelope::Envelope,
     errors::{
         utils::{check_slice_size, check_slice_size_atleast},
-        PakeError, ProtocolError,
+        ProtocolError,
     },
     group::Group,
     key_exchange::traits::{FromBytes, KeyExchange, ToBytes},
@@ -65,7 +65,7 @@ impl<CS: CipherSuite> RegistrationRequest<CS> {
 
         // Throw an error if the identity group element is encountered
         if alpha.is_identity() {
-            return Err(PakeError::IdentityGroupElementError.into());
+            return Err(ProtocolError::IdentityGroupElementError);
         }
         Ok(Self { alpha })
     }
@@ -118,7 +118,7 @@ impl<CS: CipherSuite> RegistrationResponse<CS> {
 
         // Throw an error if the identity group element is encountered
         if beta.is_identity() {
-            return Err(PakeError::IdentityGroupElementError.into());
+            return Err(ProtocolError::IdentityGroupElementError);
         }
 
         // Ensure that public key is valid
@@ -255,7 +255,7 @@ impl<CS: CipherSuite> CredentialRequest<CS> {
 
         // Throw an error if the identity group element is encountered
         if alpha.is_identity() {
-            return Err(PakeError::IdentityGroupElementError.into());
+            return Err(ProtocolError::IdentityGroupElementError);
         }
 
         let ke1_message =
@@ -347,7 +347,7 @@ impl<CS: CipherSuite> CredentialResponse<CS> {
 
         // Throw an error if the identity group element is encountered
         if beta.is_identity() {
-            return Err(PakeError::IdentityGroupElementError.into());
+            return Err(ProtocolError::IdentityGroupElementError);
         }
 
         let masking_nonce = checked_slice[elem_len..elem_len + nonce_len].to_vec();

--- a/src/serialization/mod.rs
+++ b/src/serialization/mod.rs
@@ -3,16 +3,16 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use crate::errors::PakeError;
+use crate::errors::ProtocolError;
 use alloc::vec::Vec;
 
 // Corresponds to the I2OSP() function from RFC8017
-pub(crate) fn i2osp(input: usize, length: usize) -> Result<alloc::vec::Vec<u8>, PakeError> {
+pub(crate) fn i2osp(input: usize, length: usize) -> Result<alloc::vec::Vec<u8>, ProtocolError> {
     let sizeof_usize = core::mem::size_of::<usize>();
 
     // Check if input >= 256^length
     if (sizeof_usize as u32 - input.leading_zeros() / 8) > length as u32 {
-        return Err(PakeError::SerializationError);
+        return Err(ProtocolError::SerializationError);
     }
 
     if length <= sizeof_usize {
@@ -28,9 +28,9 @@ pub(crate) fn i2osp(input: usize, length: usize) -> Result<alloc::vec::Vec<u8>, 
 }
 
 // Corresponds to the OS2IP() function from RFC8017
-pub(crate) fn os2ip(input: &[u8]) -> Result<usize, PakeError> {
+pub(crate) fn os2ip(input: &[u8]) -> Result<usize, ProtocolError> {
     if input.len() > core::mem::size_of::<usize>() {
-        return Err(PakeError::SerializationError);
+        return Err(ProtocolError::SerializationError);
     }
 
     let mut output_array = [0u8; core::mem::size_of::<usize>()];
@@ -39,20 +39,23 @@ pub(crate) fn os2ip(input: &[u8]) -> Result<usize, PakeError> {
 }
 
 // Computes I2OSP(len(input), max_bytes) || input
-pub(crate) fn serialize(input: &[u8], max_bytes: usize) -> Result<Vec<u8>, PakeError> {
+pub(crate) fn serialize(input: &[u8], max_bytes: usize) -> Result<Vec<u8>, ProtocolError> {
     Ok([&i2osp(input.len(), max_bytes)?, input].concat())
 }
 
 // Tokenizes an input of the format I2OSP(len(input), max_bytes) || input, outputting
 // (input, remainder)
-pub(crate) fn tokenize(input: &[u8], size_bytes: usize) -> Result<(Vec<u8>, Vec<u8>), PakeError> {
+pub(crate) fn tokenize(
+    input: &[u8],
+    size_bytes: usize,
+) -> Result<(Vec<u8>, Vec<u8>), ProtocolError> {
     if size_bytes > core::mem::size_of::<usize>() || input.len() < size_bytes {
-        return Err(PakeError::SerializationError);
+        return Err(ProtocolError::SerializationError);
     }
 
     let size = os2ip(&input[..size_bytes])?;
     if size_bytes + size > input.len() {
-        return Err(PakeError::SerializationError);
+        return Err(ProtocolError::SerializationError);
     }
 
     Ok((

--- a/src/serialization/tests.rs
+++ b/src/serialization/tests.rs
@@ -111,7 +111,7 @@ fn registration_request_roundtrip() {
 
     assert!(
         match RegistrationRequest::<Default>::deserialize(identity_bytes.as_slice()) {
-            Err(ProtocolError::VerificationError(PakeError::IdentityGroupElementError)) => true,
+            Err(ProtocolError::IdentityGroupElementError) => true,
             _ => false,
         }
     );
@@ -140,7 +140,7 @@ fn registration_response_roundtrip() {
     assert!(match RegistrationResponse::<Default>::deserialize(
         &[identity_bytes, pubkey_bytes.to_vec()].concat()
     ) {
-        Err(ProtocolError::VerificationError(PakeError::IdentityGroupElementError)) => true,
+        Err(ProtocolError::IdentityGroupElementError) => true,
         _ => false,
     });
 }
@@ -201,7 +201,7 @@ fn credential_request_roundtrip() {
     assert!(match CredentialRequest::<Default>::deserialize(
         &[identity_bytes, ke1m.to_vec()].concat()
     ) {
-        Err(ProtocolError::VerificationError(PakeError::IdentityGroupElementError)) => true,
+        Err(ProtocolError::IdentityGroupElementError) => true,
         _ => false,
     });
 }
@@ -251,7 +251,7 @@ fn credential_response_roundtrip() {
         ]
         .concat()
     ) {
-        Err(ProtocolError::VerificationError(PakeError::IdentityGroupElementError)) => true,
+        Err(ProtocolError::IdentityGroupElementError) => true,
         _ => false,
     });
 }

--- a/src/slow_hash.rs
+++ b/src/slow_hash.rs
@@ -5,7 +5,7 @@
 
 //! Trait specifying a slow hashing function
 
-use crate::{errors::InternalPakeError, hash::Hash};
+use crate::{errors::InternalError, hash::Hash};
 use alloc::vec::Vec;
 use digest::Digest;
 #[cfg(feature = "slow-hash")]
@@ -15,27 +15,21 @@ use generic_array::GenericArray;
 /// Used for the slow hashing function in OPAQUE
 pub trait SlowHash<D: Hash> {
     /// Computes the slow hashing function
-    fn hash(
-        input: GenericArray<u8, <D as Digest>::OutputSize>,
-    ) -> Result<Vec<u8>, InternalPakeError>;
+    fn hash(input: GenericArray<u8, <D as Digest>::OutputSize>) -> Result<Vec<u8>, InternalError>;
 }
 
 /// A no-op hash which simply returns its input
 pub struct NoOpHash;
 
 impl<D: Hash> SlowHash<D> for NoOpHash {
-    fn hash(
-        input: GenericArray<u8, <D as Digest>::OutputSize>,
-    ) -> Result<Vec<u8>, InternalPakeError> {
+    fn hash(input: GenericArray<u8, <D as Digest>::OutputSize>) -> Result<Vec<u8>, InternalError> {
         Ok(input.to_vec())
     }
 }
 
 #[cfg(feature = "slow-hash")]
 impl<D: Hash> SlowHash<D> for argon2::Argon2<'_> {
-    fn hash(
-        input: GenericArray<u8, <D as Digest>::OutputSize>,
-    ) -> Result<Vec<u8>, InternalPakeError> {
+    fn hash(input: GenericArray<u8, <D as Digest>::OutputSize>) -> Result<Vec<u8>, InternalError> {
         let params = argon2::Argon2::default();
         let mut output = alloc::vec![0u8; <D as Digest>::OutputSize::USIZE];
         params
@@ -46,7 +40,7 @@ impl<D: Hash> SlowHash<D> for argon2::Argon2<'_> {
                 &[],
                 &mut output,
             )
-            .map_err(|_| InternalPakeError::SlowHashError)?;
+            .map_err(|_| InternalError::SlowHashError)?;
         Ok(output)
     }
 }

--- a/src/tests/full_test.rs
+++ b/src/tests/full_test.rs
@@ -763,7 +763,7 @@ fn test_complete_flow(
         );
     } else {
         assert!(match client_login_result {
-            Err(ProtocolError::VerificationError(PakeError::InvalidLoginError)) => true,
+            Err(ProtocolError::InvalidLoginError) => true,
             _ => false,
         });
     }

--- a/src/tests/voprf_test_vectors.rs
+++ b/src/tests/voprf_test_vectors.rs
@@ -125,7 +125,7 @@ fn test_blind<G: Group, H: Hash>(tvs: &[&str]) -> Result<(), ProtocolError> {
 }
 
 // Tests sksm, blinded_element -> evaluation_element
-fn test_evaluate<G: Group>(tvs: &[&str]) -> Result<(), PakeError> {
+fn test_evaluate<G: Group>(tvs: &[&str]) -> Result<(), ProtocolError> {
     for tv in tvs {
         let parameters = populate_test_vectors(&serde_json::from_str(tv).unwrap());
         let evaluation_element = oprf::evaluate::<G>(


### PR DESCRIPTION
Getting rid of `PakeError`, and leaving only `InternalError` and `ProtocolError`. Also removing a bunch of unused errors.

Closes #215 