### PR TITLE
Remove Copy trait implementation from InnerEnvelopeMode

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -65,7 +65,7 @@ fn recover_keys_internal<CS: CipherSuite>(
     Ok(client_static_keypair)
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Zeroize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Zeroize)]
 #[zeroize(drop)]
 pub(crate) enum InnerEnvelopeMode {
     Zero = 0,
@@ -102,7 +102,7 @@ pub(crate) struct Envelope<CS: CipherSuite> {
 impl<CS: CipherSuite> Clone for Envelope<CS> {
     fn clone(&self) -> Self {
         Self {
-            mode: self.mode,
+            mode: self.mode.clone(),
             nonce: self.nonce.clone(),
             hmac: self.hmac.clone(),
         }


### PR DESCRIPTION
This PR fixes the following compile error by removing a trait that could not be derived.

```
error[E0184]: the trait `Copy` may not be implemented for this type; the type has a destructor
  --> src/envelope.rs:68:17
   |
68 | #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Zeroize)]
   |                 ^^^^ Copy not allowed on types with destructors
   |
   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0184`.
error: could not compile `opaque-ke` due to previous error
```

Thank you for your hard work, I love the library.