### PR TITLE
Adding support for thumbv6m-none-eabi

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,14 +137,18 @@ jobs:
         target:
           # for wasm
           - wasm32-unknown-unknown
+          # for any no_std target
+          - thumbv6m-none-eabi
         backend_feature:
           - u64_backend
           - u32_backend
+        frontend_feature:
+          - slow-hash
     steps:
       - uses: actions/checkout@v2
       - uses: hecrj/setup-rust-action@v1
       - run: rustup target add ${{ matrix.target }}
-      - run: cargo build --verbose --target=${{ matrix.target }} --no-default-features --features ${{ matrix.backend_feature }}
+      - run: cargo build --verbose --target=${{ matrix.target }} --no-default-features --features ${{ matrix.frontend_feature }} --features ${{ matrix.backend_feature }}
 
   benches:
     name: cargo bench compilation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,12 @@ authors = ["Kevin Lewi <klewi@fb.com>", "François Garillot <fga@fb.com>"]
 license = "MIT"
 edition = "2018"
 readme = "README.md"
+resolver = "2"
 
 [features]
 default = ["u64_backend"]
 slow-hash = ["scrypt"]
-std = ["curve25519-dalek/std"]
+std = ["curve25519-dalek/std", "getrandom", "rand/std", "rand/std_rng"]
 bench = []
 u64_backend = ["curve25519-dalek/u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
@@ -22,17 +23,18 @@ u32_backend = ["curve25519-dalek/u32_backend"]
 constant_time_eq = "0.1"
 curve25519-dalek = { version = "3", default-features = false }
 digest = "0.9"
-displaydoc = "0.1"
+displaydoc = { version = "0.2", default-features = false }
 generic-array = "0.14"
-generic-bytes = { version = "0.1" }
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.2", optional = true }
 hkdf = "0.11"
 hmac = "0.11"
-rand = "0.8"
-scrypt = { version = "0.5", optional = true }
+rand = { version = "0.8", default-features = false }
+scrypt = { version = "0.5", default-features = false, optional = true }
 subtle = { version = "2.3", default-features = false }
-thiserror = "1"
 zeroize = { version = "1", features = ["zeroize_derive"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"], optional = true }
 
 [dev-dependencies]
 anyhow = "1"
@@ -41,6 +43,7 @@ chacha20poly1305 = "0.8"
 criterion = "0.3"
 hex = "0.4"
 lazy_static = "1"
+opaque-ke = { path = "", default-features = false, features = ["std"] }
 serde_json = "1"
 sha2 = "0.9"
 proptest = "1"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,23 +37,26 @@ pub enum InternalPakeError {
     HmacError,
     /// Computing the slow hashing function failed
     SlowHashError,
-    /// This error occurs when the envelope seal fails
     /// Constructing the envelope seal failed.
     SealError,
-    /// This error occurs when the envelope seal open fails
     /// Opening the envelope seal failed.
     SealOpenError,
-    /// This error occurs when the envelope seal open hmac check fails
     /// HMAC check in seal open failed.
     SealOpenHmacError,
-    /// This error occurs when the envelope cannot be constructed properly
-    /// based on the credentials that were specified to be required.
+    /**
+     * This error occurs when the envelope cannot be constructed properly
+     * based on the credentials that were specified to be required.
+     */
     InvalidEnvelopeStructureError,
-    /// This error occurs when attempting to open an envelope of the wrong
-    /// type (base mode, custom identifier)
+    /**
+     * This error occurs when attempting to open an envelope of the wrong
+     * type (base mode, custom identifier)
+     */
     IncompatibleEnvelopeModeError,
-    /// This error occurs when the envelope is opened and deserialization
-    /// fails
+    /**
+     * This error occurs when the envelope is opened and deserialization
+     * fails
+     */
     UnexpectedEnvelopeContentsError,
 }
 
@@ -63,11 +66,8 @@ impl Error for InternalPakeError {}
 /// Represents an error in password checking
 #[derive(Debug, Display)]
 pub enum PakeError {
-    /// This error results from an internal error during PRF construction
-    ///
     /// Internal error during PRF verification: {0}
     CryptoError(InternalPakeError),
-    /// This error occurs when the server object that is being called finish() on is malformed
     /// Incomplete set of keys passed into finish() function
     IncompleteKeysError,
     /// The provided server public key doesn't match the sealed one
@@ -96,21 +96,21 @@ impl Error for PakeError {}
 /// Represents an error in protocol handling
 #[derive(Debug, Display)]
 pub enum ProtocolError {
-    /// This error results from an error during password verification
-    ///
     /// Internal error during password verification: {0}
     VerificationError(PakeError),
-    /// This error occurs when the server answer cannot be handled
     /// Server response cannot be handled.
     ServerError,
-    /// This error occurs when the server specifies an envelope credentials
-    /// format that is invalid
+    /**
+     * This error occurs when the server specifies an envelope credentials
+     * format that is invalid
+     */
     ServerInvalidEnvelopeCredentialsFormatError,
-    /// This error occurs when the client request cannot be handled
     /// Client request cannot be handled.
     ClientError,
-    /// This error occurs when the client detects that the server has
-    /// reflected the OPRF value (beta == alpha)
+    /**
+     * This error occurs when the client detects that the server has
+     * reflected the OPRF value (beta == alpha)
+     */
     ReflectedValueError,
 }
 
@@ -139,24 +139,6 @@ impl From<InternalPakeError> for ProtocolError {
 impl From<::core::convert::Infallible> for ProtocolError {
     fn from(_: ::core::convert::Infallible) -> Self {
         unreachable!()
-    }
-}
-
-impl From<generic_bytes::TryFromSizedBytesError> for InternalPakeError {
-    fn from(_: generic_bytes::TryFromSizedBytesError) -> Self {
-        InternalPakeError::InvalidByteSequence
-    }
-}
-
-impl From<generic_bytes::TryFromSizedBytesError> for PakeError {
-    fn from(e: generic_bytes::TryFromSizedBytesError) -> Self {
-        PakeError::CryptoError(e.into())
-    }
-}
-
-impl From<generic_bytes::TryFromSizedBytesError> for ProtocolError {
-    fn from(e: generic_bytes::TryFromSizedBytesError) -> Self {
-        PakeError::CryptoError(e.into()).into()
     }
 }
 

--- a/src/key_exchange/tripledh.rs
+++ b/src/key_exchange/tripledh.rs
@@ -12,7 +12,7 @@ use crate::{
     group::Group,
     hash::Hash,
     key_exchange::traits::{KeyExchange, ToBytes, ToBytesWithPointers},
-    keypair::{Key, KeyPair, SizedBytesExt},
+    keypair::{Key, KeyPair},
     serialization::{serialize, tokenize},
 };
 use alloc::vec::Vec;
@@ -22,7 +22,6 @@ use generic_array::{
     typenum::{Unsigned, U32},
     ArrayLength, GenericArray,
 };
-use generic_bytes::SizedBytes;
 use hkdf::Hkdf;
 use hmac::{Hmac, Mac, NewMac};
 use rand::{CryptoRng, RngCore};
@@ -278,10 +277,7 @@ impl ToBytesWithPointers for Ke1State {
     #[cfg(test)]
     fn as_byte_ptrs(&self) -> Vec<(*const u8, usize)> {
         alloc::vec![
-            (
-                self.client_e_sk.as_ptr(),
-                <Key as SizedBytes>::Len::to_usize(),
-            ),
+            (self.client_e_sk.as_ptr(), Key::LEN,),
             (self.client_nonce.as_ptr(), NonceLen::to_usize()),
         ]
     }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -14,12 +14,11 @@ use crate::{
     },
     group::Group,
     key_exchange::traits::{KeyExchange, ToBytes},
-    keypair::{Key, KeyPair, SizedBytesExt},
+    keypair::{Key, KeyPair},
 };
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use generic_array::{typenum::Unsigned, GenericArray};
-use generic_bytes::SizedBytes;
 
 // Messages
 // =========
@@ -86,7 +85,7 @@ impl<CS: CipherSuite> RegistrationResponse<CS> {
     /// Deserialization from bytes
     pub fn deserialize(input: &[u8]) -> Result<Self, ProtocolError> {
         let elem_len = <CS::Group as Group>::ElemLen::to_usize();
-        let key_len = <Key as SizedBytes>::Len::to_usize();
+        let key_len = Key::LEN;
         let checked_slice =
             check_slice_size(input, elem_len + key_len, "registration_response_bytes")?;
 
@@ -143,7 +142,7 @@ impl<CS: CipherSuite> RegistrationUpload<CS> {
 
     /// Deserialization from bytes
     pub fn deserialize(input: &[u8]) -> Result<Self, ProtocolError> {
-        let key_len = <Key as SizedBytes>::Len::to_usize();
+        let key_len = Key::LEN;
 
         let checked_slice = check_slice_size_atleast(input, key_len, "registration_upload_bytes")?;
 
@@ -246,7 +245,7 @@ impl<CS: CipherSuite> CredentialResponse<CS> {
     /// Deserialization from bytes
     pub fn deserialize(input: &[u8]) -> Result<Self, ProtocolError> {
         let elem_len = <CS::Group as Group>::ElemLen::to_usize();
-        let key_len = <Key as SizedBytes>::Len::to_usize();
+        let key_len = Key::LEN;
         let checked_slice =
             check_slice_size_atleast(input, elem_len + key_len, "login_second_message_bytes")?;
 

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -12,7 +12,7 @@ use crate::{
     group::Group,
     hash::Hash,
     key_exchange::traits::{KeyExchange, ToBytesWithPointers},
-    keypair::{Key, KeyPair, SizedBytesExt},
+    keypair::{Key, KeyPair},
     map_to_curve::GroupWithMapToCurve,
     oprf,
     serialization::{serialize, tokenize},
@@ -24,7 +24,6 @@ use alloc::vec::Vec;
 use core::{convert::TryFrom, marker::PhantomData};
 use digest::Digest;
 use generic_array::{typenum::Unsigned, GenericArray};
-use generic_bytes::SizedBytes;
 use rand::{CryptoRng, RngCore};
 use zeroize::Zeroize;
 
@@ -275,7 +274,7 @@ impl<CS: CipherSuite> ServerRegistration<CS> {
         }
 
         // Need to do this check manually because envelope is variable-size
-        let key_len = <Key as SizedBytes>::Len::to_usize();
+        let key_len = Key::LEN;
 
         let checked_bytes =
             check_slice_size_atleast(input, scalar_len + key_len, "server_registration_bytes")?;

--- a/src/serialization/tests.rs
+++ b/src/serialization/tests.rs
@@ -24,7 +24,6 @@ use alloc::vec::Vec;
 
 use curve25519_dalek::{ristretto::RistrettoPoint, traits::Identity};
 use generic_array::typenum::Unsigned;
-use generic_bytes::SizedBytes;
 use proptest::{collection::vec, prelude::*};
 use rand::{rngs::OsRng, RngCore};
 

--- a/src/tests/full_test.rs
+++ b/src/tests/full_test.rs
@@ -6,14 +6,8 @@
 #![allow(unsafe_code)]
 
 use crate::{
-    ciphersuite::CipherSuite,
-    errors::*,
-    key_exchange::tripledh::TripleDH,
-    keypair::{Key, SizedBytesExt},
-    opaque::*,
-    slow_hash::NoOpHash,
-    tests::mock_rng::CycleRng,
-    *,
+    ciphersuite::CipherSuite, errors::*, key_exchange::tripledh::TripleDH, keypair::Key, opaque::*,
+    slow_hash::NoOpHash, tests::mock_rng::CycleRng, *,
 };
 
 #[cfg(feature = "std")]
@@ -30,7 +24,6 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::slice::from_raw_parts;
 use curve25519_dalek::{ristretto::RistrettoPoint, traits::Identity};
-use generic_bytes::SizedBytes;
 use rand::rngs::OsRng;
 use serde_json::Value;
 use zeroize::Zeroize;

--- a/src/tests/opaque_test_vectors.rs
+++ b/src/tests/opaque_test_vectors.rs
@@ -4,14 +4,8 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::{
-    ciphersuite::CipherSuite,
-    errors::*,
-    key_exchange::tripledh::TripleDH,
-    keypair::{Key, SizedBytesExt},
-    opaque::*,
-    slow_hash::NoOpHash,
-    tests::mock_rng::CycleRng,
-    *,
+    ciphersuite::CipherSuite, errors::*, key_exchange::tripledh::TripleDH, keypair::Key, opaque::*,
+    slow_hash::NoOpHash, tests::mock_rng::CycleRng, *,
 };
 use alloc::string::String;
 use alloc::string::ToString;


### PR DESCRIPTION
Mirrors the changes from https://github.com/novifinancial/opaque-ke/pull/229/commits/c7e897b6a613450cde5667bf3a7984e7afa3625a for v1 branch