### PR TITLE
Addressing taplo-cli install issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -246,7 +246,9 @@ jobs:
           key: taplo
 
       - name: Install Taplo
-        run: cargo install taplo-cli
+        # Adding the --locked flag because of
+        # https://github.com/tamasfe/taplo/issues/242
+        run: cargo install taplo-cli --locked 
 
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION
Installing taplo-cli started failing recently, see: https://github.com/tamasfe/taplo/issues/242