### PR TITLE
Adding documentation on RegistrationUpload and removing patch voprf in Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.0-pre.2 (April 22, 2022)
+* Synced implementation with draft-irtf-cfrg-opaque-08
+
 ## 2.0.0-pre.1 (March 15, 2022)
 
 * Synced implementation with draft-irtf-cfrg-opaque-07

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "opaque-ke"
 readme = "README.md"
 repository = "https://github.com/novifinancial/opaque-ke"
 rust-version = "1.57"
-version = "2.0.0-pre.1"
+version = "2.0.0-pre.2"
 
 [features]
 default = ["ristretto255-u64", "ristretto255-voprf", "serde"]
@@ -77,6 +77,3 @@ name = "opaque"
 [package.metadata.docs.rs]
 features = ["argon2", "std", "x25519-u64"]
 targets = []
-
-[patch.crates-io]
-voprf = { git = "https://github.com/novifinancial/voprf", branch = "main" }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Installation
 Add the following line to the dependencies of your `Cargo.toml`:
 
 ```
-opaque-ke = "2.0.0-pre.1"
+opaque-ke = "2.0.0-pre.2"
 ```
 
 ### Minimum Supported Rust Version

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,10 @@
 //! for each client, and the values consist of their corresponding password
 //! files, to be retrieved upon future login attempts made by the client.
 //!
+//! Note that the [RegistrationUpload] message contains sensitive information
+//! (about as sensitive as a hash of the password), and hence should be
+//! protected with confidentiality guarantees by the consumer of this library.
+//!
 //! ### Client Registration Start
 //! In the first step of registration, the client chooses as input a
 //! registration password. The client runs [ClientRegistration::start] to


### PR DESCRIPTION
Closes #262 and #260, ready for release 2.0.0-pre.2.