### PR TITLE
Change argon2 salt length to recommended value (16 bytes)

### DIFF
--- a/src/ksf.rs
+++ b/src/ksf.rs
@@ -11,6 +11,10 @@ use generic_array::{ArrayLength, GenericArray};
 
 use crate::errors::InternalError;
 
+/// Recommended salt length for argon2-based password hashing.
+#[cfg(feature = "argon2")]
+const ARGON2_RECOMMENDED_SALT_LEN: usize = 16;
+
 /// Used for the key stretching function in OPAQUE
 pub trait Ksf: Default {
     /// Computes the key stretching function
@@ -40,7 +44,7 @@ impl Ksf for argon2::Argon2<'_> {
         input: GenericArray<u8, L>,
     ) -> Result<GenericArray<u8, L>, InternalError> {
         let mut output = GenericArray::default();
-        self.hash_password_into(&input, &[0; argon2::MIN_SALT_LEN], &mut output)
+        self.hash_password_into(&input, &[0; ARGON2_RECOMMENDED_SALT_LEN], &mut output)
             .map_err(|_| InternalError::KsfError)?;
         Ok(output)
     }


### PR DESCRIPTION
This pull request changes the `Ksf` implementation for Argon2 and sets the salt length to 16 bytes (instead of the minimal length of 8 bytes), the value recommended for password hashing in section 3.1 of the Argon2 specification.
This also serves to improve interoperability: for example, with this change, it's possible to use `opaque-ke` in conjunction with `libopaque`, since it also uses a 16-byte salt by default.

Note that this will make existing registrations (i.e., those made with an 8-byte salt) invalid, since KSF parameters (including salt length) must stay the same across registration and login.