### PR TITLE
Document responsibility for server-side id. #276

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,9 +89,9 @@
 //! key-value database, where the keys consist of these server-side identifiers
 //! for each client, and the values consist of their corresponding password
 //! files, to be retrieved upon future login attempts made by the client.
-//! It is your responsibility to ensure that the identifier given by the
-//! client in the initial [RegistrationRequest] is the database key you use
-//! in the final [RegistrationUpload] step.
+//! It is your responsibility to ensure that the identifier used to form the
+//! initial [RegistrationRequest] matches the database key used in the final
+//! [RegistrationUpload] step.
 //!
 //! Note that the [RegistrationUpload] message contains sensitive information
 //! (about as sensitive as a hash of the password), and hence should be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,8 +90,8 @@
 //! for each client, and the values consist of their corresponding password
 //! files, to be retrieved upon future login attempts made by the client.
 //! It is your responsibility to ensure that the identifier used to form the
-//! initial [RegistrationRequest] matches the database key used in the final
-//! [RegistrationUpload] step.
+//! initial [RegistrationRequest], typically supplied by the client, matches
+//! the database key used in the final [RegistrationUpload] step.
 //!
 //! Note that the [RegistrationUpload] message contains sensitive information
 //! (about as sensitive as a hash of the password), and hence should be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,9 @@
 //! key-value database, where the keys consist of these server-side identifiers
 //! for each client, and the values consist of their corresponding password
 //! files, to be retrieved upon future login attempts made by the client.
+//! It is your responsibility to ensure that the identifier given by the
+//! client in the initial [RegistrationRequest] is the database key you use
+//! in the final [RegistrationUpload] step.
 //!
 //! Note that the [RegistrationUpload] message contains sensitive information
 //! (about as sensitive as a hash of the password), and hence should be


### PR DESCRIPTION
This is a passive warning to the server implementor to not blindly trust the client to send the same identifier in both `RegistrationRequest` and `RegistrationUpload`.