### PR TITLE
Fixing voprf dependency pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.0-pre.3 (July 11, 2022)
+* Synced implementation with draft-irtf-cfrg-opaque-10
+* Changed argon2 salt length to recommended value (16 bytes)
+* Fixed issue from 2.0.0-pre.2 not pinning voprf dependency correctly
+
 ## 2.0.0-pre.2 (April 22, 2022)
 * Synced implementation with draft-irtf-cfrg-opaque-08
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ serde_ = { version = "1", package = "serde", default-features = false, features 
   "derive",
 ], optional = true }
 subtle = { version = "2.3", default-features = false }
-voprf = { version = "0.4.0-pre.3", default-features = false, features = [
+voprf = { version = "=0.4.0-pre.3", default-features = false, features = [
   "danger",
 ] }
 zeroize = { version = "1.5", features = ["zeroize_derive"] }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Resources
 ---------
 
 - [OPAQUE academic publication](https://eprint.iacr.org/2018/163.pdf), including formal definitions and a proof of security
-- [draft-irtf-cfrg-opaque-08](https://datatracker.ietf.org/doc/draft-irtf-cfrg-opaque/08/), containing a detailed (byte-level) specification for OPAQUE
+- [draft-irtf-cfrg-opaque-10](https://datatracker.ietf.org/doc/draft-irtf-cfrg-opaque/10/), containing a detailed (byte-level) specification for OPAQUE
 - ["Let's talk about PAKE"](https://blog.cryptographyengineering.com/2018/10/19/lets-talk-about-pake/), an introductory blog post written by Matthew Green that covers OPAQUE
 - [opaque-wasm](https://github.com/marucjmar/opaque-wasm), a WebAssembly package for this library
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! An implementation of the OPAQUE asymmetric password authentication key
 //! exchange protocol
 //!
-//! Note: This implementation is in sync with [draft-irtf-cfrg-opaque-08](https://datatracker.ietf.org/doc/draft-irtf-cfrg-opaque/08/),
+//! Note: This implementation is in sync with [draft-irtf-cfrg-opaque-10](https://datatracker.ietf.org/doc/draft-irtf-cfrg-opaque/10/),
 //! but this specification is subject to change, until the final version
 //! published by the IETF.
 //!


### PR DESCRIPTION
Fixes #279 and prepares for a v2.0.0-pre.3 release by updating some documentation